### PR TITLE
Improve crash logging initialization and process-mode routing

### DIFF
--- a/Battman/CrashLogger.h
+++ b/Battman/CrashLogger.h
@@ -9,13 +9,24 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef NS_ENUM(NSInteger, CrashLoggerProcessMode) {
+	CrashLoggerProcessModeApp = 0,
+	CrashLoggerProcessModeDaemon,
+	CrashLoggerProcessModeWorker,
+	CrashLoggerProcessModeUnknown,
+};
+
 @interface CrashLogger : NSObject
+
+/// Configure crash logging destination for the current process mode.
+/// This must be called before installing handlers.
++ (void)configureForProcessMode:(CrashLoggerProcessMode)mode;
 
 /// Install crash handlers (NSException and signal handlers)
 + (void)installCrashHandlers;
 
 /// Get path to crash log file
-/// Log files are stored at: battman_config_dir()/CrashLogs/BattmanCrash_YYYY_MM_DD_HHMMSS.log
+/// Log files are stored under a crash-specific directory and include process mode in filename.
 /// Each app launch creates a new timestamped log file
 + (NSString *)crashLogPath;
 

--- a/Battman/CrashLogger.m
+++ b/Battman/CrashLogger.m
@@ -7,142 +7,237 @@
 
 #import "CrashLogger.h"
 #import "common.h"
+
+#include <errno.h>
 #include <execinfo.h>
+#include <fcntl.h>
 #include <signal.h>
-#include <UIKit/UIKit.h>
-#include <sys/utsname.h>
 #include <sys/stat.h>
+#include <sys/utsname.h>
+#include <unistd.h>
 
 // Forward declarations for C handler functions
 static void uncaughtExceptionHandler(NSException *exception);
 static void signalHandler(int sig);
 
 static NSString *crashLogFilePath = nil;
+static int crashLogFD = -1;
+static volatile sig_atomic_t crashModeForSignals = CrashLoggerProcessModeUnknown;
+static volatile sig_atomic_t handlingSignal = 0;
+
+static const char *crash_logger_mode_name_c(CrashLoggerProcessMode mode) {
+	switch (mode) {
+		case CrashLoggerProcessModeApp:
+			return "app";
+		case CrashLoggerProcessModeDaemon:
+			return "daemon";
+		case CrashLoggerProcessModeWorker:
+			return "worker";
+		default:
+			return "unknown";
+	}
+}
+
+static NSString *crash_logger_mode_name_ns(CrashLoggerProcessMode mode) {
+	return [NSString stringWithUTF8String:crash_logger_mode_name_c(mode)];
+}
+
+static void signal_safe_write(int fd, const char *bytes, size_t len) {
+	if (fd < 0 || bytes == NULL || len == 0)
+		return;
+	while (len > 0) {
+		ssize_t wrote = write(fd, bytes, len);
+		if (wrote > 0) {
+			bytes += wrote;
+			len -= (size_t)wrote;
+			continue;
+		}
+		if (wrote == -1 && errno == EINTR)
+			continue;
+		break;
+	}
+}
+
+#define WRITE_LITERAL(fd, lit) signal_safe_write((fd), (lit), sizeof(lit) - 1)
+
+static void write_signal_mode(int fd) {
+	switch ((CrashLoggerProcessMode)crashModeForSignals) {
+		case CrashLoggerProcessModeApp:
+			WRITE_LITERAL(fd, "app");
+			break;
+		case CrashLoggerProcessModeDaemon:
+			WRITE_LITERAL(fd, "daemon");
+			break;
+		case CrashLoggerProcessModeWorker:
+			WRITE_LITERAL(fd, "worker");
+			break;
+		default:
+			WRITE_LITERAL(fd, "unknown");
+			break;
+	}
+}
+
+static void write_signal_name(int fd, int sig) {
+	switch (sig) {
+		case SIGSEGV:
+			WRITE_LITERAL(fd, "SIGSEGV");
+			break;
+		case SIGABRT:
+			WRITE_LITERAL(fd, "SIGABRT");
+			break;
+		case SIGBUS:
+			WRITE_LITERAL(fd, "SIGBUS");
+			break;
+		case SIGILL:
+			WRITE_LITERAL(fd, "SIGILL");
+			break;
+		case SIGFPE:
+			WRITE_LITERAL(fd, "SIGFPE");
+			break;
+		default:
+			WRITE_LITERAL(fd, "UNKNOWN");
+			break;
+	}
+}
 
 @implementation CrashLogger
 
-+ (void)initialize {
-    if (self == [CrashLogger class]) {
-        // Set up crash log file path using battman_config_dir()/CrashLogs/
-        const char *configDir = battman_config_dir();
-        if (configDir) {
-            NSString *crashLogsDir = [[NSString stringWithUTF8String:configDir] stringByAppendingPathComponent:@"CrashLogs"];
-            
-            // Create CrashLogs directory if it doesn't exist
-            NSFileManager *fileManager = [NSFileManager defaultManager];
-            NSError *error = nil;
-            [fileManager createDirectoryAtPath:crashLogsDir withIntermediateDirectories:YES attributes:nil error:&error];
-            
-            if (error) {
-                NSLog(@"[CrashLogger] Failed to create crash logs directory: %@", error);
-            }
-            
-            // Generate timestamped filename: BattmanCrash_YYYY_MM_DD_HHMMSS.log
-            NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
-            [formatter setDateFormat:@"yyyy_MM_dd_HHmmss"];
-            NSString *timestamp = [formatter stringFromDate:[NSDate date]];
-            NSString *filename = [NSString stringWithFormat:@"BattmanCrash_%@.log", timestamp];
-            
-            crashLogFilePath = [crashLogsDir stringByAppendingPathComponent:filename];
-        } else {
-            NSLog(@"[CrashLogger] Warning: battman_config_dir() returned NULL, falling back to Documents directory");
-            NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
-            NSString *documentsDirectory = [paths firstObject];
-            crashLogFilePath = [documentsDirectory stringByAppendingPathComponent:@"Battman_Crash.log"];
-        }
-    }
++ (NSString *)resolvedCrashLogsDirectory {
+	const char *configDir = battman_config_dir();
+	if (configDir && configDir[0] != '\0') {
+		return [[NSString stringWithUTF8String:configDir] stringByAppendingPathComponent:@"CrashLogs"];
+	}
+
+	NSArray<NSString *> *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+	NSString *documentsDirectory = paths.firstObject;
+	if (documentsDirectory.length > 0) {
+		return [documentsDirectory stringByAppendingPathComponent:@"CrashLogs"];
+	}
+
+	NSString *tmpDir = NSTemporaryDirectory();
+	if (tmpDir.length == 0) {
+		tmpDir = @"/tmp";
+	}
+	return [tmpDir stringByAppendingPathComponent:@"BattmanCrashLogs"];
+}
+
++ (void)configureForProcessMode:(CrashLoggerProcessMode)mode {
+	@synchronized(self) {
+		if (crashLogFD != -1)
+			return;
+
+		crashModeForSignals = (sig_atomic_t)mode;
+
+		NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+		[formatter setDateFormat:@"yyyy_MM_dd_HHmmss"];
+		NSString *timestamp = [formatter stringFromDate:[NSDate date]];
+		NSString *filename = [NSString stringWithFormat:@"BattmanCrash_%@_%@.log", timestamp, crash_logger_mode_name_ns(mode)];
+
+		NSFileManager *fileManager = [NSFileManager defaultManager];
+		NSString *crashLogsDir = [self resolvedCrashLogsDirectory];
+		NSError *error = nil;
+		if ([fileManager createDirectoryAtPath:crashLogsDir withIntermediateDirectories:YES attributes:nil error:&error]) {
+			NSString *path = [crashLogsDir stringByAppendingPathComponent:filename];
+			int fd = open(path.fileSystemRepresentation, O_WRONLY | O_CREAT | O_APPEND, 0644);
+			if (fd != -1) {
+				crashLogFD = fd;
+				crashLogFilePath = path;
+			}
+		}
+
+		if (crashLogFD == -1) {
+			NSLog(@"[CrashLogger] Failed to initialize crash log file for mode %@", crash_logger_mode_name_ns(mode));
+		}
+	}
 }
 
 + (NSString *)crashLogPath {
-    return crashLogFilePath;
+	return crashLogFilePath ?: @"";
 }
 
 + (void)installCrashHandlers {
-    NSLog(@"[CrashLogger] Installing crash handlers. Log file: %@", crashLogFilePath);
-    
-    // Install NSException handler
-    NSSetUncaughtExceptionHandler(&uncaughtExceptionHandler);
-    
-    // Install signal handlers for common crashes
-    signal(SIGSEGV, signalHandler);  // Segmentation fault
-    signal(SIGABRT, signalHandler);  // Abort
-    signal(SIGBUS, signalHandler);   // Bus error
-    signal(SIGILL, signalHandler);   // Illegal instruction
-    signal(SIGFPE, signalHandler);   // Floating point exception
-    signal(SIGTRAP, signalHandler);  // Trap
+	static dispatch_once_t onceToken;
+	dispatch_once(&onceToken, ^{
+		NSSetUncaughtExceptionHandler(&uncaughtExceptionHandler);
+		signal(SIGSEGV, signalHandler);
+		signal(SIGABRT, signalHandler);
+		signal(SIGBUS, signalHandler);
+		signal(SIGILL, signalHandler);
+		signal(SIGFPE, signalHandler);
+	});
 }
 
 + (void)logMessage:(NSString *)message {
-    if (!crashLogFilePath) return;
-    
-    NSString *timestamp = [self timestamp];
-    NSString *logEntry = [NSString stringWithFormat:@"[%@] %@\n", timestamp, message];
-    
-    NSFileManager *fileManager = [NSFileManager defaultManager];
-    if (![fileManager fileExistsAtPath:crashLogFilePath]) {
-        [logEntry writeToFile:crashLogFilePath atomically:YES encoding:NSUTF8StringEncoding error:nil];
-    } else {
-        NSFileHandle *fileHandle = [NSFileHandle fileHandleForWritingAtPath:crashLogFilePath];
-        [fileHandle seekToEndOfFile];
-        [fileHandle writeData:[logEntry dataUsingEncoding:NSUTF8StringEncoding]];
-        [fileHandle closeFile];
-    }
+	if (message.length == 0 || crashLogFD == -1)
+		return;
+
+	@synchronized(self) {
+		NSString *logEntry = [NSString stringWithFormat:@"[%@] %@\n", [self timestamp], message];
+		NSData *data = [logEntry dataUsingEncoding:NSUTF8StringEncoding];
+		if (data.length == 0)
+			return;
+
+		const char *bytes = data.bytes;
+		size_t remaining = data.length;
+		while (remaining > 0) {
+			ssize_t wrote = write(crashLogFD, bytes, remaining);
+			if (wrote > 0) {
+				bytes += wrote;
+				remaining -= (size_t)wrote;
+				continue;
+			}
+			if (wrote == -1 && errno == EINTR)
+				continue;
+			break;
+		}
+	}
 }
 
 + (NSString *)timestamp {
-    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
-    [formatter setDateFormat:@"yyyy-MM-dd HH:mm:ss.SSS"];
-    return [formatter stringFromDate:[NSDate date]];
+	NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+	[formatter setDateFormat:@"yyyy-MM-dd HH:mm:ss.SSS"];
+	return [formatter stringFromDate:[NSDate date]];
 }
 
 + (NSString *)deviceInfo {
-    struct utsname systemInfo;
-    uname(&systemInfo);
-    
-    NSString *deviceModel = [NSString stringWithCString:systemInfo.machine encoding:NSUTF8StringEncoding];
-    NSString *systemVersion = [[UIDevice currentDevice] systemVersion];
-    
-    return [NSString stringWithFormat:@"Device: %@, iOS: %@", deviceModel, systemVersion];
+	struct utsname systemInfo;
+	uname(&systemInfo);
+
+	NSString *deviceModel = [NSString stringWithCString:systemInfo.machine encoding:NSUTF8StringEncoding];
+	NSString *systemVersion = [[NSProcessInfo processInfo] operatingSystemVersionString];
+
+	return [NSString stringWithFormat:@"Device: %@, OS: %@", deviceModel, systemVersion];
 }
 
 + (NSString *)stackTrace {
-    void *callstack[128];
-    int frames = backtrace(callstack, 128);
-    char **symbols = backtrace_symbols(callstack, frames);
-    
-    NSMutableString *stackTrace = [NSMutableString stringWithString:@"Stack Trace:\n"];
-    for (int i = 0; i < frames; i++) {
-        [stackTrace appendFormat:@"%s\n", symbols[i]];
-    }
-    free(symbols);
-    
-    return stackTrace;
+	void *callstack[128];
+	int frames = backtrace(callstack, 128);
+	char **symbols = backtrace_symbols(callstack, frames);
+
+	NSMutableString *stackTrace = [NSMutableString stringWithString:@"Stack Trace:\n"];
+	for (int i = 0; i < frames; i++) {
+		[stackTrace appendFormat:@"%s\n", symbols[i]];
+	}
+	free(symbols);
+
+	return stackTrace;
 }
 
 + (void)logCrashWithType:(NSString *)type reason:(NSString *)reason {
-    NSMutableString *crashLog = [NSMutableString string];
-    
-    [crashLog appendString:@"\n========================================\n"];
-    [crashLog appendFormat:@"CRASH REPORT - %@\n", [self timestamp]];
-    [crashLog appendString:@"========================================\n\n"];
-    
-    [crashLog appendFormat:@"Crash Type: %@\n", type];
-	[crashLog appendFormat:@"Battman working type: %@\n", (gAppType == BATTMAN_APP) ? @"App" : @"Subprocess"];
-    [crashLog appendFormat:@"%@\n\n", [self deviceInfo]];
-    
-    if (reason) {
-        [crashLog appendFormat:@"Reason: %@\n\n", reason];
-    }
-    
-    [crashLog appendFormat:@"%@\n", [self stackTrace]];
-    
-    [crashLog appendString:@"========================================\n\n"];
-    
-    // Write to file
-    [self logMessage:crashLog];
-    
-    // Also log to console
-    NSLog(@"%@", crashLog);
+	NSMutableString *crashLog = [NSMutableString string];
+
+	[crashLog appendString:@"\n========================================\n"];
+	[crashLog appendFormat:@"CRASH REPORT - %@\n", [self timestamp]];
+	[crashLog appendString:@"========================================\n\n"];
+	[crashLog appendFormat:@"Crash Type: %@\n", type ?: @"Unknown"];
+	[crashLog appendFormat:@"Process Mode: %@\n", crash_logger_mode_name_ns((CrashLoggerProcessMode)crashModeForSignals)];
+	[crashLog appendFormat:@"%@\n\n", [self deviceInfo]];
+	if (reason.length > 0) {
+		[crashLog appendFormat:@"Reason: %@\n\n", reason];
+	}
+	[crashLog appendFormat:@"%@\n", [self stackTrace]];
+	[crashLog appendString:@"========================================\n"];
+	[self logMessage:crashLog];
 }
 
 @end
@@ -150,36 +245,33 @@ static NSString *crashLogFilePath = nil;
 #pragma mark - C Exception and Signal Handlers
 
 static void uncaughtExceptionHandler(NSException *exception) {
-    NSString *reason = [NSString stringWithFormat:@"%@ - %@", 
-                        exception.name, exception.reason];
-    
-    NSMutableString *stackInfo = [NSMutableString stringWithString:reason];
-    [stackInfo appendString:@"\n\nCall Stack:\n"];
-    
-    for (NSString *symbol in exception.callStackSymbols) {
-        [stackInfo appendFormat:@"%@\n", symbol];
-    }
-    
-    [CrashLogger logCrashWithType:@"NSException" reason:stackInfo];
-    
-    // Let the system handle the exception after logging
+	NSString *reason = [NSString stringWithFormat:@"%@ - %@", exception.name, exception.reason];
+	NSMutableString *stackInfo = [NSMutableString stringWithString:reason];
+	[stackInfo appendString:@"\n\nCall Stack:\n"];
+	for (NSString *symbol in exception.callStackSymbols) {
+		[stackInfo appendFormat:@"%@\n", symbol];
+	}
+	[CrashLogger logCrashWithType:@"NSException" reason:stackInfo];
 }
 
 static void signalHandler(int sig) {
-    NSString *signalName = @"UNKNOWN";
-    switch (sig) {
-        case SIGSEGV: signalName = @"SIGSEGV (Segmentation Fault)"; break;
-        case SIGABRT: signalName = @"SIGABRT (Abort)"; break;
-        case SIGBUS: signalName = @"SIGBUS (Bus Error)"; break;
-        case SIGILL: signalName = @"SIGILL (Illegal Instruction)"; break;
-        case SIGFPE: signalName = @"SIGFPE (Floating Point Exception)"; break;
-        case SIGTRAP: signalName = @"SIGTRAP (Trap)"; break;
-    }
-    
-    NSString *reason = [NSString stringWithFormat:@"Signal %d received: %@", sig, signalName];
-    [CrashLogger logCrashWithType:@"Signal" reason:reason];
-    
-    // Reset to default handler and re-raise
-    signal(sig, SIG_DFL);
-    raise(sig);
+	if (handlingSignal) {
+		signal(sig, SIG_DFL);
+		raise(sig);
+		return;
+	}
+
+	handlingSignal = 1;
+	if (crashLogFD != -1) {
+		WRITE_LITERAL(crashLogFD, "\n========================================\n");
+		WRITE_LITERAL(crashLogFD, "SIGNAL CRASH\n");
+		WRITE_LITERAL(crashLogFD, "Mode: ");
+		write_signal_mode(crashLogFD);
+		WRITE_LITERAL(crashLogFD, "\nSignal: ");
+		write_signal_name(crashLogFD, sig);
+		WRITE_LITERAL(crashLogFD, "\n========================================\n");
+	}
+
+	signal(sig, SIG_DFL);
+	raise(sig);
 }

--- a/Battman/CrashLogger.m
+++ b/Battman/CrashLogger.m
@@ -164,6 +164,7 @@ static void write_signal_name(int fd, int sig) {
 		signal(SIGBUS, signalHandler);
 		signal(SIGILL, signalHandler);
 		signal(SIGFPE, signalHandler);
+		signal(SIGTRAP, signalHandler);
 	});
 }
 

--- a/Battman/main.m
+++ b/Battman/main.m
@@ -298,10 +298,32 @@ os_log_t gLog;
 os_log_t gLogDaemon;
 battman_type_t gAppType = BATTMAN_SUBPROCESS;
 
+static CrashLoggerProcessMode crash_logger_detect_process_mode(int argc, char *argv[]) {
+	if (argc == 3 && strcmp(argv[1], "--worker") == 0)
+		return CrashLoggerProcessModeWorker;
+	if (argc == 2 && strcmp(argv[1], "--daemon") == 0)
+		return CrashLoggerProcessModeDaemon;
+	return CrashLoggerProcessModeApp;
+}
+
+static const char *crash_logger_process_mode_name(CrashLoggerProcessMode mode) {
+	switch (mode) {
+		case CrashLoggerProcessModeApp:
+			return "app";
+		case CrashLoggerProcessModeDaemon:
+			return "daemon";
+		case CrashLoggerProcessModeWorker:
+			return "worker";
+		default:
+			return "unknown";
+	}
+}
+
 int main(int argc, char * argv[]) {
-	// Install crash handlers early
+	CrashLoggerProcessMode processMode = crash_logger_detect_process_mode(argc, argv);
+	[CrashLogger configureForProcessMode:processMode];
 	[CrashLogger installCrashHandlers];
-	[CrashLogger logMessage:@"=== App Started ==="];
+	[CrashLogger logMessage:[NSString stringWithFormat:@"=== Process Started (%s) ===", crash_logger_process_mode_name(processMode)]];
 	
 	gLog = os_log_create("com.torrekie.Battman", "default");
 	if (gLog == NULL) {
@@ -310,11 +332,11 @@ int main(int argc, char * argv[]) {
 
 	pull_fatal_notif();
     // FIXME: use getopt()
-	if (argc == 3 && strcmp(argv[1], "--worker") == 0) {
+	if (processMode == CrashLoggerProcessModeWorker) {
 		extern void battman_run_worker(const char *);
 		battman_run_worker(argv[2]);
 		return 0;
-	} else if (argc == 2 && strcmp(argv[1], "--daemon") == 0) {
+	} else if (processMode == CrashLoggerProcessModeDaemon) {
 		gLogDaemon = os_log_create("com.torrekie.Battman", "Daemon");
 		if (gLogDaemon == NULL) {
 			os_log_error(OS_LOG_DEFAULT, "Couldn't create daemon os log object");


### PR DESCRIPTION
## Summary
- configure crash logger before handler installation based on process mode (app/daemon/worker)
- write mode-specific log filenames under CrashLogs
- harden signal crash logging with signal-safe writes and reentry guard

## Why
- ensure crashes are logged consistently from any scene/process path
- avoid mode ambiguity when diagnosing app vs daemon vs worker failures

## Testing
- xcodebuild -project Battman.xcodeproj -scheme Battman -configuration Debug -sdk iphoneos CODE_SIGNING_ALLOWED=NO build