### PR TITLE
Avoid main-thread deadlocks in battery status callbacks

### DIFF
--- a/Battman/BatterySubscriberViewControllerBase.c
+++ b/Battman/BatterySubscriberViewControllerBase.c
@@ -1,6 +1,8 @@
 #include "cobjc/cobjc.h"
 #include "common.h"
 #include "BattmanPrefs.h"
+#include <pthread.h>
+#include <stdlib.h>
 #include <string.h>
 
 // Extern UIApplication notification names as CFStringRef
@@ -133,17 +135,53 @@ static void BSVCBatteryStatusCallback1(void **userInfo) {
 	}
 }
 
+typedef struct {
+	void *observer;
+	CFDictionaryRef userInfo;
+} BSVCBatteryStatusPayload;
+
+static void BSVCBatteryStatusCallbackMain(void *ctx) {
+	BSVCBatteryStatusPayload *payload = (BSVCBatteryStatusPayload *)ctx;
+	if (!payload) return;
+
+	void *observerAndUserInfo[2] = {
+		payload->observer,
+		(void *)payload->userInfo
+	};
+	BSVCBatteryStatusCallback1(observerAndUserInfo);
+
+	if (payload->userInfo) {
+		CFRelease(payload->userInfo);
+	}
+	free(payload);
+}
+
 static void BSVCBatteryStatusCallback(CFNotificationCenterRef center, void *observer, CFNotificationName name, const void *object, CFDictionaryRef userInfo) {
 	if (gNotificationsPaused) {
 		return;
 	}
 
-	void *observerAndUserInfo[2] = {
-		observer,
-		(void *)userInfo
-	};
-	dispatch_sync_f(dispatch_get_main_queue(), observerAndUserInfo, (void (*)(void *))BSVCBatteryStatusCallback1);
-	// stack variable is ok bc it waits until execution finishes
+	if (pthread_main_np()) {
+		void *observerAndUserInfo[2] = {
+			observer,
+			(void *)userInfo
+		};
+		BSVCBatteryStatusCallback1(observerAndUserInfo);
+	} else {
+		BSVCBatteryStatusPayload *payload = calloc(1, sizeof(BSVCBatteryStatusPayload));
+		if (!payload) {
+			void *observerAndUserInfo[2] = {
+				observer,
+				(void *)userInfo
+			};
+			dispatch_sync_f(dispatch_get_main_queue(), observerAndUserInfo, (void (*)(void *))BSVCBatteryStatusCallback1);
+			return;
+		}
+
+		payload->observer = observer;
+		payload->userInfo = userInfo ? (CFDictionaryRef)CFRetain(userInfo) : NULL;
+		dispatch_async_f(dispatch_get_main_queue(), payload, BSVCBatteryStatusCallbackMain);
+	}
 }
 
 // CFNotificationCenter callback for app lifecycle events

--- a/Battman/BatterySubscriberViewControllerBase.c
+++ b/Battman/BatterySubscriberViewControllerBase.c
@@ -153,6 +153,9 @@ static void BSVCBatteryStatusCallbackMain(void *ctx) {
 	if (payload->userInfo) {
 		CFRelease(payload->userInfo);
 	}
+	if (payload->observer) {
+		NSObjectRelease((id)payload->observer);
+	}
 	free(payload);
 }
 
@@ -170,15 +173,19 @@ static void BSVCBatteryStatusCallback(CFNotificationCenterRef center, void *obse
 	} else {
 		BSVCBatteryStatusPayload *payload = calloc(1, sizeof(BSVCBatteryStatusPayload));
 		if (!payload) {
+			id retainedObserver = observer ? NSObjectRetain((id)observer) : NULL;
 			void *observerAndUserInfo[2] = {
-				observer,
+				retainedObserver,
 				(void *)userInfo
 			};
 			dispatch_sync_f(dispatch_get_main_queue(), observerAndUserInfo, (void (*)(void *))BSVCBatteryStatusCallback1);
+			if (retainedObserver) {
+				NSObjectRelease(retainedObserver);
+			}
 			return;
 		}
 
-		payload->observer = observer;
+		payload->observer = observer ? NSObjectRetain((id)observer) : NULL;
 		payload->userInfo = userInfo ? (CFDictionaryRef)CFRetain(userInfo) : NULL;
 		dispatch_async_f(dispatch_get_main_queue(), payload, BSVCBatteryStatusCallbackMain);
 	}


### PR DESCRIPTION
## Summary
- avoid direct synchronous main-queue dispatch from notification callback paths
- if already on main thread, execute callback directly
- otherwise, retain payload and dispatch async to main safely

## Why
- prevents deadlock risk and reduces callback-induced UI stalls

## Testing
- xcodebuild -project Battman.xcodeproj -scheme Battman -configuration Debug -sdk iphoneos CODE_SIGNING_ALLOWED=NO build