### PR TITLE
Serialize battery refresh and coalesce UI updates

### DIFF
--- a/Battman/BatteryCellView/BatteryInfoTableViewCell.m
+++ b/Battman/BatteryCellView/BatteryInfoTableViewCell.m
@@ -46,6 +46,7 @@
 
 - (void)updateBatteryInfo {
 	NSString *final_str = @"";
+	battery_info_read_lock();
 	// TODO: Arabian? We need Arabian hackers to fix this code
 	for (struct battery_info_section *sect = *_batteryInfo; sect; sect = sect->next) {
 		if (sect->context->custom_identifier != BI_GAS_GAUGE_SECTION_ID)
@@ -79,6 +80,7 @@
 			// Only show in details if is string
 		}
 	}
+	battery_info_unlock();
 	if (!final_str.length)
 		return;
 	_batteryLabel.text = [final_str substringFromIndex:1];

--- a/Battman/BatteryDetailsViewController.h
+++ b/Battman/BatteryDetailsViewController.h
@@ -7,7 +7,6 @@
 	// There should be strictly ONE (1) head pointer stored
 	// (which is left in BatteryInfoViewController)
 	struct battery_info_section **batteryInfo;
-	unsigned char *pendingLoadOffsets[BI_MAX_SECTION_NUM];
 
 	int last_charging;
 }

--- a/Battman/BatteryDetailsViewController.m
+++ b/Battman/BatteryDetailsViewController.m
@@ -13,6 +13,7 @@
 #import "ObjCExt/UIColor+compat.h"
 
 #import <CoreText/CoreText.h>
+#include <string.h>
 #include <sys/sysctl.h>
 
 /* Desc */
@@ -21,6 +22,10 @@
 	int8_t      hvc_index;
 	size_t      hvc_menu_size;
 	bool        hvc_soft;
+	bool        hvc_menu_owned;
+	dispatch_queue_t refreshQueue;
+	BOOL        refreshInFlight;
+	BOOL        refreshPending;
 }
 @end
 
@@ -231,15 +236,89 @@ void equipWarningCondition_b(UITableViewCell *equippedCell, NSString *textLabel,
 	[super viewWillAppear:animated];
 	// Update refresh mode based on current preferences
 	BSVCRefreshModeDidUpdate(self);
-	// Defer battery update to avoid blocking main thread during view transition
-	dispatch_async(dispatch_get_main_queue(), ^{
-		[self updateTableView];
-	});
+	[self updateTableView];
 }
 
 - (void)refreshModeDidUpdate {
 	// Called when preferences change
 	BSVCRefreshModeDidUpdate(self);
+}
+
+- (void)_startQueuedRefresh {
+	if (refreshInFlight) {
+		refreshPending = YES;
+		return;
+	}
+
+	if (!self.refreshControl.refreshing) {
+		[self.refreshControl beginRefreshing];
+	}
+	refreshInFlight = YES;
+	dispatch_async(refreshQueue, ^{
+		battery_info_update(self->batteryInfo);
+
+		device_info_t adapter_info;
+		is_charging(NULL, &adapter_info);
+
+		hvc_menu_t *new_hvc_menu = NULL;
+		size_t new_hvc_menu_size = 0;
+		int8_t new_hvc_index = 0;
+		bool new_hvc_soft = false;
+		bool new_hvc_owned = false;
+
+		/* Parse HVC Modes if have any */
+		if (adapter_info.hvc_menu[27] != 0xFF) {
+			new_hvc_menu = hvc_menu_parse(adapter_info.hvc_menu, &new_hvc_menu_size);
+			new_hvc_index = adapter_info.hvc_index;
+			new_hvc_soft = false;
+			new_hvc_owned = (new_hvc_menu != NULL);
+		} else {
+			new_hvc_soft = true;
+			/* Avoid IOKit includes, we only use this one */
+			extern CFDictionaryRef IOPSCopyExternalPowerAdapterDetails(void);
+			new_hvc_menu = convert_hvc(IOPSCopyExternalPowerAdapterDetails(), &new_hvc_menu_size, &new_hvc_index);
+			new_hvc_owned = (new_hvc_menu != NULL);
+		}
+#if TARGET_OS_SIMULATOR
+		/* Simulator builds cannot use IOPSCopyExternalPowerAdapterDetails() */
+		/* We fake some hvc to test the UI instead */
+		static hvc_menu_t fake_hvc[2];
+		memset(fake_hvc, 0, sizeof(fake_hvc));
+		fake_hvc[0].voltage = 114;
+		fake_hvc[0].current = 514;
+		fake_hvc[1].voltage = 1919;
+		fake_hvc[1].current = 810;
+		new_hvc_index = 1;
+		new_hvc_menu = fake_hvc;
+		new_hvc_menu_size = 2;
+		new_hvc_owned = false;
+#endif
+
+		dispatch_async(dispatch_get_main_queue(), ^{
+			self->refreshInFlight = NO;
+
+			if (self->hvc_menu_owned && self->hvc_menu && self->hvc_menu != new_hvc_menu) {
+				free(self->hvc_menu);
+			}
+			self->hvc_menu = new_hvc_menu;
+			self->hvc_menu_size = new_hvc_menu_size;
+			self->hvc_index = new_hvc_index;
+			self->hvc_soft = new_hvc_soft;
+			self->hvc_menu_owned = new_hvc_owned;
+
+			if ([self isViewLoaded] && self.view.window) {
+				[self.tableView reloadData];
+			}
+			[self.refreshControl endRefreshing];
+
+			if (self->refreshPending) {
+				if (!(self.tableView.dragging || self.tableView.decelerating || self.tableView.tracking)) {
+					self->refreshPending = NO;
+					[self _startQueuedRefresh];
+				}
+			}
+		});
+	});
 }
 
 - (void)batteryStatusDidUpdate:(NSDictionary *)info {
@@ -319,8 +398,15 @@ void equipWarningCondition_b(UITableViewCell *equippedCell, NSString *textLabel,
 	}
 
 	self.tableView.allowsSelection = YES;
-	battery_info_update(bi);
 	batteryInfo = bi;
+	refreshQueue = dispatch_queue_create("com.torrekie.Battman.BDVCRefresh", DISPATCH_QUEUE_SERIAL);
+	refreshInFlight = NO;
+	refreshPending = NO;
+	hvc_menu_owned = false;
+	hvc_menu = NULL;
+	hvc_menu_size = 0;
+	hvc_index = -1;
+	hvc_soft = false;
 	for (int i = 0; i < BI_MAX_SECTION_NUM; i++)
 		pendingLoadOffsets[i] = malloc(BI_APPROX_ROWS);
 	if (!hasSMC)
@@ -334,62 +420,40 @@ void equipWarningCondition_b(UITableViewCell *equippedCell, NSString *textLabel,
 	//int section_num = battery_info_get_section_count(*batteryInfo);
 	for (int i = 0; i < BI_MAX_SECTION_NUM; i++)
 		free(pendingLoadOffsets[i]);
+	if (hvc_menu_owned && hvc_menu) {
+		free(hvc_menu);
+		hvc_menu = NULL;
+	}
 }
 
 - (void)updateTableView {
-	DBGLOG(@"BDVC: updateTableView");
-	[self.refreshControl beginRefreshing];
-	
-	// Move heavy SMC operations to background queue to avoid blocking main thread during view transition
-	dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
-		battery_info_update(self->batteryInfo);
-		
-		// Update HVC data in background to avoid blocking scrolling
-		device_info_t adapter_info;
-		is_charging(NULL, &adapter_info);
-		
-		hvc_menu_t *new_hvc_menu = NULL;
-		size_t new_hvc_menu_size = 0;
-		int8_t new_hvc_index = 0;
-		bool new_hvc_soft = false;
-		
-		/* Parse HVC Modes if have any */
-		if (adapter_info.hvc_menu[27] != 0xFF) {
-			new_hvc_menu = hvc_menu_parse(adapter_info.hvc_menu, &new_hvc_menu_size);
-			new_hvc_index = adapter_info.hvc_index;
-			new_hvc_soft = false;
-		} else {
-			new_hvc_soft = true;
-			/* Avoid IOKit includes, we only use this one */
-			extern CFDictionaryRef IOPSCopyExternalPowerAdapterDetails(void);
-			new_hvc_menu = convert_hvc(IOPSCopyExternalPowerAdapterDetails(), &new_hvc_menu_size, &new_hvc_index);
-		}
-#if TARGET_OS_SIMULATOR
-		/* Simulator builds cannot use IOPSCopyExternalPowerAdapterDetails() */
-		/* We fake some hvc to test the UI instead */
-		static hvc_menu_t fake_hvc[2];
-		memset(fake_hvc, 0, sizeof(fake_hvc));
-		fake_hvc[0].voltage = 114;
-		fake_hvc[0].current = 514;
-		fake_hvc[1].voltage = 1919;
-		fake_hvc[1].current = 810;
-		new_hvc_index = 1;
-		new_hvc_menu = fake_hvc;
-		new_hvc_menu_size = 2;
-#endif
-
-		// Update UI on main thread
+	if (![NSThread isMainThread]) {
 		dispatch_async(dispatch_get_main_queue(), ^{
-			// Update cached HVC data
-			self->hvc_menu = new_hvc_menu;
-			self->hvc_menu_size = new_hvc_menu_size;
-			self->hvc_index = new_hvc_index;
-			self->hvc_soft = new_hvc_soft;
-			
-			[self.tableView reloadData];
-			[self.refreshControl endRefreshing];
+			[self updateTableView];
 		});
-	});
+		return;
+	}
+
+	DBGLOG(@"BDVC: updateTableView");
+	if (self.tableView.dragging || self.tableView.decelerating || self.tableView.tracking) {
+		refreshPending = YES;
+		return;
+	}
+	[self _startQueuedRefresh];
+}
+
+- (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView {
+	if (refreshPending && !refreshInFlight) {
+		refreshPending = NO;
+		[self _startQueuedRefresh];
+	}
+}
+
+- (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate {
+	if (!decelerate && refreshPending && !refreshInFlight) {
+		refreshPending = NO;
+		[self _startQueuedRefresh];
+	}
 }
 
 - (void)tableView:(UITableView *)tableView accessoryButtonTappedForRowWithIndexPath:(NSIndexPath *)indexPath {
@@ -410,7 +474,21 @@ void equipWarningCondition_b(UITableViewCell *equippedCell, NSString *textLabel,
 		titleLabel = cell.textLabel.text;
 	}
 
-	show_alert([titleLabel UTF8String], _C(battery_info_get_section(*batteryInfo, (int)indexPath.section)->data[indexPath.row + pendingLoadOffsets[indexPath.section][indexPath.row]].desc), L_OK);
+	char *desc_copy = NULL;
+	battery_info_read_lock();
+	struct battery_info_section *section = battery_info_get_section(*batteryInfo, (int)indexPath.section);
+	if (section) {
+		struct battery_info_node *node = section->data + indexPath.row + pendingLoadOffsets[indexPath.section][indexPath.row];
+		if (node && node->desc) {
+			desc_copy = strdup(node->desc);
+		}
+	}
+	battery_info_unlock();
+
+	show_alert([titleLabel UTF8String], desc_copy ? _C(desc_copy) : "", L_OK);
+	if (desc_copy) {
+		free(desc_copy);
+	}
 	return;
 	// TODO: Implement this
 #if 0
@@ -462,16 +540,34 @@ void equipWarningCondition_b(UITableViewCell *equippedCell, NSString *textLabel,
 
 - (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section {
 	UITableViewHeaderFooterView *header = (UITableViewHeaderFooterView *)view;
-	header.textLabel.text               = _(battery_info_get_section(*batteryInfo, section)->data[0].name);
+	NSString *title = nil;
+	battery_info_read_lock();
+	struct battery_info_section *sect = battery_info_get_section(*batteryInfo, section);
+	if (sect && sect->data[0].name) {
+		title = _(sect->data[0].name);
+	}
+	battery_info_unlock();
+	header.textLabel.text = title ?: @"";
 }
 
 - (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section {
+	NSString *footer = nil;
+	battery_info_read_lock();
 	struct battery_info_section *cur = battery_info_get_section(*batteryInfo, section);
-	return cur->data[0].desc ? _(cur->data[0].desc) : nil;
+	if (cur && cur->data[0].desc) {
+		footer = _(cur->data[0].desc);
+	}
+	battery_info_unlock();
+	return footer;
 }
 
 - (NSInteger)tableView:(id)tv numberOfRowsInSection:(NSInteger)section {
+	battery_info_read_lock();
 	struct battery_info_section *sect = battery_info_get_section(*batteryInfo, section);
+	if (!sect) {
+		battery_info_unlock();
+		return 0;
+	}
 	int                          rows = 0;
 	for (struct battery_info_node *i = sect->data + 1; i->name /*&& (i->content & BIN_SECTION) != BIN_SECTION*/; i++) {
 		if ((i->content & BIN_DETAILS_SHARED) == BIN_DETAILS_SHARED || (i->content && !((i->content & BIN_IS_SPECIAL) == BIN_IS_SPECIAL))) {
@@ -482,11 +578,15 @@ void equipWarningCondition_b(UITableViewCell *equippedCell, NSString *textLabel,
 		}
 	}
 	pendingLoadOffsets[section][rows] = 255;
+	battery_info_unlock();
 	return rows;
 }
 
 - (NSInteger)numberOfSectionsInTableView:(id)tv {
-	return battery_info_get_section_count(*batteryInfo);
+	battery_info_read_lock();
+	int count = battery_info_get_section_count(*batteryInfo);
+	battery_info_unlock();
+	return count;
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tv cellForRowAtIndexPath:(NSIndexPath *)ip {
@@ -505,7 +605,12 @@ void equipWarningCondition_b(UITableViewCell *equippedCell, NSString *textLabel,
 		cell = [[cell_class alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:ident];
 	}
 	
+	battery_info_read_lock();
 	struct battery_info_section *bi_section = battery_info_get_section(*batteryInfo, ip.section);
+	if (!bi_section) {
+		battery_info_unlock();
+		return cell;
+	}
 	struct battery_info_node    *pending_bi = bi_section->data + ip.row + pendingLoadOffsets[ip.section][ip.row];
 	/* Flags special handler */
 #pragma clang diagnostic push
@@ -520,13 +625,14 @@ void equipWarningCondition_b(UITableViewCell *equippedCell, NSString *textLabel,
 		cellf.titleLabel.text      = _(pending_bi->name);
 		cellf.detailTextLabel.text = _(bi_node_get_string(pending_bi));
 		[cellf selectByFlags:gGauge.Flags];
-		if (strlen(gGauge.DeviceName)) {
-			[cellf setBitSetByModel:[NSString stringWithFormat:@"%s", gGauge.DeviceName]];
-		} else {
-			[cellf setBitSetByTargetName];
+			if (strlen(gGauge.DeviceName)) {
+				[cellf setBitSetByModel:[NSString stringWithFormat:@"%s", gGauge.DeviceName]];
+			} else {
+				[cellf setBitSetByTargetName];
+			}
+			battery_info_unlock();
+			return cellf;
 		}
-		return cellf;
-	}
 #pragma clang diagnostic pop
 
 #pragma mark - Warn Conditions
@@ -699,9 +805,9 @@ void equipWarningCondition_b(UITableViewCell *equippedCell, NSString *textLabel,
 			}
 
 			/* Content */
-			if (!hvc_soft && (hvc_index > hvc_menu_size)) {
-				cell_seg.detailTextLabel.text    = [NSString stringWithFormat:@"%d (%@)", hvc_index, _("Not HVC")];
-				cell_seg.subTitleLabel.text  = @" ";
+				if (!hvc_soft && (hvc_index > hvc_menu_size)) {
+					cell_seg.detailTextLabel.text    = [NSString stringWithFormat:@"%d (%@)", hvc_index, _("Not HVC")];
+					cell_seg.subTitleLabel.text  = @" ";
 				cell_seg.subDetailLabel.text = @" ";
 			} else if (hvc_soft == true) {
 				cell_seg.detailTextLabel.text = [NSString stringWithFormat:@"%d (%@)", hvc_index, _("Software Controlled")];
@@ -718,15 +824,17 @@ void equipWarningCondition_b(UITableViewCell *equippedCell, NSString *textLabel,
 				[cell_seg.segmentedControl setSelectedSegmentIndex:hvc_index];
 				/* Why its not refreshing label after setSelectedSegmentIndex? */
 				cell_seg.subTitleLabel.text  = [NSString stringWithFormat:@"%d %s", hvc_menu[hvc_index].voltage, L_MV];
-				cell_seg.subDetailLabel.text = [NSString stringWithFormat:@"%d %s", hvc_menu[hvc_index].current, L_MA];
-			}
+					cell_seg.subDetailLabel.text = [NSString stringWithFormat:@"%d %s", hvc_menu[hvc_index].current, L_MA];
+				}
 
-			return cell_seg;
-		} else {
-			cell.detailTextLabel.text = _("None");
+				battery_info_unlock();
+				return cell_seg;
+			} else {
+				cell.detailTextLabel.text = _("None");
+			}
 		}
-	}
-	//        [cell layoutIfNeeded];
+		//        [cell layoutIfNeeded];
+	battery_info_unlock();
 	return cell;
 }
 
@@ -752,10 +860,17 @@ void equipWarningCondition_b(UITableViewCell *equippedCell, NSString *textLabel,
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
 	[tableView deselectRowAtIndexPath:indexPath animated:YES];
+	battery_info_write_lock();
 	struct battery_info_section *bi_section = battery_info_get_section(*batteryInfo, indexPath.section);
-	struct battery_info_node    *pending_bi = bi_section->data + indexPath.row + pendingLoadOffsets[indexPath.section][indexPath.row];
-	if(!(pending_bi->content&BIN_HAS_SUBCELLS))
+	if (!bi_section) {
+		battery_info_unlock();
 		return;
+	}
+	struct battery_info_node    *pending_bi = bi_section->data + indexPath.row + pendingLoadOffsets[indexPath.section][indexPath.row];
+	if(!(pending_bi->content&BIN_HAS_SUBCELLS)) {
+		battery_info_unlock();
+		return;
+	}
 	int rows=0;
 	int is_hidden=0;
 	NSMutableArray *indexPaths=[NSMutableArray array];
@@ -766,8 +881,11 @@ void equipWarningCondition_b(UITableViewCell *equippedCell, NSString *textLabel,
 		rows++;
 		[indexPaths addObject:[NSIndexPath indexPathForRow:indexPath.row+rows inSection:indexPath.section]];
 	}
-	if(!rows)
+	if(!rows) {
+		battery_info_unlock();
 		return;
+	}
+	battery_info_unlock();
 	if(is_hidden) {
 		[tableView insertRowsAtIndexPaths:indexPaths withRowAnimation:UITableViewRowAnimationAutomatic];
 	}else{

--- a/Battman/BatteryDetailsViewController.m
+++ b/Battman/BatteryDetailsViewController.m
@@ -410,7 +410,7 @@ void equipWarningCondition_b(UITableViewCell *equippedCell, NSString *textLabel,
 			new_hvc_menu = hvc_menu_parse(adapter_info.hvc_menu, &new_hvc_menu_size);
 			new_hvc_index = adapter_info.hvc_index;
 			new_hvc_soft = false;
-			new_hvc_owned = (new_hvc_menu != NULL);
+			new_hvc_owned = false;
 		} else {
 			new_hvc_soft = true;
 			/* Avoid IOKit includes, we only use this one */

--- a/Battman/BatteryDetailsViewController.m
+++ b/Battman/BatteryDetailsViewController.m
@@ -60,6 +60,9 @@
 	dispatch_queue_t refreshQueue;
 	BOOL        refreshInFlight;
 	BOOL        refreshPending;
+	BOOL        refreshSuspended;
+	NSUInteger  refreshGeneration;
+	NSUInteger  refreshInFlightGeneration;
 	BDVCBatteryInfoTableSnapshot *batteryInfoSnapshot;
 }
 @end
@@ -367,6 +370,10 @@ void equipWarningCondition_b(UITableViewCell *equippedCell, NSString *textLabel,
 
 @implementation BatteryDetailsViewController
 
+- (BOOL)_canScheduleRefresh {
+	return !refreshSuspended && [UIApplication sharedApplication].applicationState != UIApplicationStateBackground;
+}
+
 - (NSString *)title {
 	return _("Internal Battery");
 }
@@ -384,8 +391,16 @@ void equipWarningCondition_b(UITableViewCell *equippedCell, NSString *textLabel,
 }
 
 - (void)_startQueuedRefresh {
+	if (![self _canScheduleRefresh]) {
+		refreshPending = NO;
+		[self.refreshControl endRefreshing];
+		return;
+	}
+
 	if (refreshInFlight) {
-		refreshPending = YES;
+		if (refreshInFlightGeneration != refreshGeneration) {
+			refreshPending = YES;
+		}
 		return;
 	}
 
@@ -393,6 +408,8 @@ void equipWarningCondition_b(UITableViewCell *equippedCell, NSString *textLabel,
 		[self.refreshControl beginRefreshing];
 	}
 	refreshInFlight = YES;
+	NSUInteger generation = refreshGeneration;
+	refreshInFlightGeneration = generation;
 	dispatch_async(refreshQueue, ^{
 		battery_info_update(self->batteryInfo);
 
@@ -436,6 +453,20 @@ void equipWarningCondition_b(UITableViewCell *equippedCell, NSString *textLabel,
 		BDVCBatteryInfoTableSnapshot *newSnapshot = BDVCCopyBatteryInfoSnapshot(self->batteryInfo);
 		dispatch_async(dispatch_get_main_queue(), ^{
 			self->refreshInFlight = NO;
+			if (generation != self->refreshGeneration || ![self _canScheduleRefresh]) {
+				BOOL shouldRestart = self->refreshPending && [self _canScheduleRefresh] &&
+					!(self.tableView.dragging || self.tableView.decelerating || self.tableView.tracking);
+				self->refreshPending = NO;
+				if (new_hvc_owned && new_hvc_menu) {
+					free(new_hvc_menu);
+				}
+				[self.refreshControl endRefreshing];
+				if (shouldRestart) {
+					[self _startQueuedRefresh];
+				}
+				return;
+			}
+
 			self->batteryInfoSnapshot = newSnapshot;
 
 			if (self->hvc_menu_owned && self->hvc_menu && self->hvc_menu != new_hvc_menu) {
@@ -489,11 +520,29 @@ void equipWarningCondition_b(UITableViewCell *equippedCell, NSString *textLabel,
 #endif
 }
 
+- (void)applicationDidEnterBackground:(NSNotification *)notification {
+	refreshSuspended = YES;
+	refreshPending = NO;
+	refreshGeneration++;
+	if (!refreshInFlight) {
+		[self.refreshControl endRefreshing];
+	}
+}
+
+- (void)applicationWillEnterForeground:(NSNotification *)notification {
+	refreshSuspended = NO;
+	refreshGeneration++;
+}
+
 - (void)viewDidLoad {
 	[super viewDidLoad];
 	UIRefreshControl *puller = [[UIRefreshControl alloc] init];
 	[puller addTarget:self action:@selector(updateTableView) forControlEvents:UIControlEventValueChanged];
 	self.refreshControl = puller;
+
+	NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
+	[center addObserver:self selector:@selector(applicationDidEnterBackground:) name:UIApplicationDidEnterBackgroundNotification object:nil];
+	[center addObserver:self selector:@selector(applicationWillEnterForeground:) name:UIApplicationWillEnterForegroundNotification object:nil];
 
 	// FIXME: use preferred_language() for "Copy"
 	[[UIMenuController sharedMenuController] update];
@@ -539,6 +588,9 @@ void equipWarningCondition_b(UITableViewCell *equippedCell, NSString *textLabel,
 	}
 
 	self.tableView.allowsSelection = YES;
+	refreshSuspended = [UIApplication sharedApplication].applicationState == UIApplicationStateBackground;
+	refreshGeneration = 0;
+	refreshInFlightGeneration = 0;
 	batteryInfo = bi;
 	batteryInfoSnapshot = BDVCCopyBatteryInfoSnapshot(bi);
 	refreshQueue = dispatch_queue_create("com.torrekie.Battman.BDVCRefresh", DISPATCH_QUEUE_SERIAL);
@@ -557,6 +609,7 @@ void equipWarningCondition_b(UITableViewCell *equippedCell, NSString *textLabel,
 }
 
 - (void)dealloc {
+	[[NSNotificationCenter defaultCenter] removeObserver:self];
 	if (hvc_menu_owned && hvc_menu) {
 		free(hvc_menu);
 		hvc_menu = NULL;
@@ -572,6 +625,12 @@ void equipWarningCondition_b(UITableViewCell *equippedCell, NSString *textLabel,
 	}
 
 	DBGLOG(@"BDVC: updateTableView");
+	if (![self _canScheduleRefresh]) {
+		refreshPending = NO;
+		[self.refreshControl endRefreshing];
+		return;
+	}
+
 	if (self.tableView.dragging || self.tableView.decelerating || self.tableView.tracking) {
 		refreshPending = YES;
 		return;

--- a/Battman/BatteryDetailsViewController.m
+++ b/Battman/BatteryDetailsViewController.m
@@ -549,8 +549,6 @@ void equipWarningCondition_b(UITableViewCell *equippedCell, NSString *textLabel,
 	hvc_menu_size = 0;
 	hvc_index = -1;
 	hvc_soft = false;
-	for (int i = 0; i < BI_MAX_SECTION_NUM; i++)
-		pendingLoadOffsets[i] = malloc(BI_APPROX_ROWS);
 	if (!hasSMC)
 		return self;
 	self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:_("Advanced") style:UIBarButtonItemStylePlain target:self action:@selector(showAdvanced)];
@@ -559,9 +557,6 @@ void equipWarningCondition_b(UITableViewCell *equippedCell, NSString *textLabel,
 }
 
 - (void)dealloc {
-	//int section_num = battery_info_get_section_count(*batteryInfo);
-	for (int i = 0; i < BI_MAX_SECTION_NUM; i++)
-		free(pendingLoadOffsets[i]);
 	if (hvc_menu_owned && hvc_menu) {
 		free(hvc_menu);
 		hvc_menu = NULL;

--- a/Battman/BatteryDetailsViewController.m
+++ b/Battman/BatteryDetailsViewController.m
@@ -16,6 +16,40 @@
 #include <string.h>
 #include <sys/sysctl.h>
 
+@class BDVCBatteryInfoTableSnapshot;
+
+@interface BDVCBatteryInfoNodeSnapshot : NSObject
+@property(nonatomic, copy) NSString *name;
+@property(nonatomic, copy) NSString *stringValue;
+@property(nonatomic, copy) NSString *desc;
+@property(nonatomic, assign) uint32_t content;
+@property(nonatomic, assign) NSUInteger sourceIndex;
+@end
+
+@implementation BDVCBatteryInfoNodeSnapshot
+@end
+
+@interface BDVCBatteryInfoSectionSnapshot : NSObject
+@property(nonatomic, copy) NSString *title;
+@property(nonatomic, copy) NSString *footer;
+@property(nonatomic, strong) NSArray<BDVCBatteryInfoNodeSnapshot *> *rows;
+@property(nonatomic, assign) uint64_t customIdentifier;
+@end
+
+@implementation BDVCBatteryInfoSectionSnapshot
+@end
+
+@interface BDVCBatteryInfoTableSnapshot : NSObject {
+@public
+	gas_gauge_t gauge;
+	int timeToEmpty;
+}
+@property(nonatomic, strong) NSArray<BDVCBatteryInfoSectionSnapshot *> *sections;
+@end
+
+@implementation BDVCBatteryInfoTableSnapshot
+@end
+
 /* Desc */
 @interface BatteryDetailsViewController () {
 	hvc_menu_t *hvc_menu;
@@ -26,6 +60,7 @@
 	dispatch_queue_t refreshQueue;
 	BOOL        refreshInFlight;
 	BOOL        refreshPending;
+	BDVCBatteryInfoTableSnapshot *batteryInfoSnapshot;
 }
 @end
 
@@ -79,6 +114,110 @@ void equipCellHighLegit(UILabel *label) {
 	if (cachedFont) {
 		[label setFont:cachedFont];
 	}
+}
+
+static NSString *BDVCStringFromUTF8(const char *str) {
+	return str ? [NSString stringWithUTF8String:str] : nil;
+}
+
+static float BDVCLoadFloatFromContent(uint32_t content) {
+	struct battery_info_node node = {0};
+	node.content = content;
+	return bi_node_load_float(&node);
+}
+
+static NSString *BDVCFormattedValueForContent(uint32_t content, NSString *stringValue) {
+	NSString *final_str;
+	if ((content & BIN_IS_SPECIAL) == BIN_IS_SPECIAL) {
+		int16_t value = content >> 16;
+
+		if ((content & BIN_IS_BOOLEAN) == BIN_IS_BOOLEAN) {
+			final_str = value ? _("True") : _("False");
+		} else if ((content & BIN_IS_FLOAT) == BIN_IS_FLOAT) {
+			final_str = [NSString stringWithFormat:@"%.4g", BDVCLoadFloatFromContent(content)];
+		} else {
+			final_str = [NSString stringWithFormat:@"%d", value];
+		}
+		if (content & BIN_HAS_UNIT) {
+			uint32_t unit = (content & BIN_UNIT_BITMASK) >> 6;
+			if (unit == (BIN_UNIT_MIN & BIN_UNIT_BITMASK) >> 6) {
+				NSDateComponentsFormatter *fmt = [[NSDateComponentsFormatter alloc] init];
+				fmt.calendar.locale            = [NSLocale localeWithLocaleIdentifier:[NSString stringWithUTF8String:preferred_language()]];
+				fmt.allowedUnits               = NSCalendarUnitDay | NSCalendarUnitHour | NSCalendarUnitMinute;
+				fmt.unitsStyle                 = NSDateComponentsFormatterUnitsStyleShort;
+				fmt.zeroFormattingBehavior     = NSDateComponentsFormatterZeroFormattingBehaviorDropAll;
+				final_str                      = [fmt stringFromTimeInterval:value * 60];
+			} else {
+				final_str                      = [NSString stringWithFormat:@"%@ %@", final_str, _(bin_unit_strings[unit])];
+			}
+		}
+	} else {
+		final_str = stringValue ?: @"";
+	}
+	return final_str ?: @"";
+}
+
+static void BDVCEquipDetailCellWithSnapshot(UITableViewCell *cell, BDVCBatteryInfoNodeSnapshot *node) {
+	NSString *name = node.name ?: @"";
+	equipCellTitle(cell, _(name.UTF8String));
+	if (node.desc) {
+		if (@available(iOS 13.0, *)) {
+			cell.accessoryType = UITableViewCellAccessoryDetailButton;
+		} else {
+			WarnAccessoryView *button = [WarnAccessoryView altAccessoryView];
+			[cell setAccessoryType:UITableViewCellAccessoryNone];
+			[cell setAccessoryView:button];
+		}
+	} else {
+		cell.accessoryType = UITableViewCellAccessoryNone;
+	}
+
+	cell.detailTextLabel.text = BDVCFormattedValueForContent(node.content, node.stringValue);
+	if ([name containsString:@"No."] || [name containsString:@"ID"]) {
+		equipCellHighLegit(cell.detailTextLabel);
+	}
+	cell.detailTextLabel.textColor = [UIColor compatSecondaryLabelColor];
+}
+
+static BDVCBatteryInfoTableSnapshot *BDVCCopyBatteryInfoSnapshot(struct battery_info_section **batteryInfo) {
+	BDVCBatteryInfoTableSnapshot *snapshot = [BDVCBatteryInfoTableSnapshot new];
+	NSMutableArray<BDVCBatteryInfoSectionSnapshot *> *sections = [NSMutableArray array];
+
+	battery_info_read_lock();
+	snapshot->gauge = gGauge;
+	snapshot->timeToEmpty = 0;
+	for (struct battery_info_section *sect = batteryInfo ? *batteryInfo : NULL; sect; sect = sect->next) {
+		BDVCBatteryInfoSectionSnapshot *sectionSnapshot = [BDVCBatteryInfoSectionSnapshot new];
+		sectionSnapshot.title = BDVCStringFromUTF8(sect->data[0].name);
+		sectionSnapshot.footer = BDVCStringFromUTF8(sect->data[0].desc);
+		sectionSnapshot.customIdentifier = sect->context ? sect->context->custom_identifier : 0;
+
+		NSMutableArray<BDVCBatteryInfoNodeSnapshot *> *rows = [NSMutableArray array];
+		for (struct battery_info_node *i = sect->data + 1; i->name; i++) {
+			if ((i->content & BIN_DETAILS_SHARED) == BIN_DETAILS_SHARED || (i->content && !((i->content & BIN_IS_SPECIAL) == BIN_IS_SPECIAL))) {
+				if ((i->content & 1) != 1 || (i->content & (1 << 5)) != (1 << 5)) {
+					BDVCBatteryInfoNodeSnapshot *nodeSnapshot = [BDVCBatteryInfoNodeSnapshot new];
+					nodeSnapshot.name = BDVCStringFromUTF8(i->name);
+					nodeSnapshot.desc = BDVCStringFromUTF8(i->desc);
+					nodeSnapshot.content = i->content;
+					nodeSnapshot.sourceIndex = (NSUInteger)(i - sect->data);
+					if (!((i->content & BIN_IS_SPECIAL) == BIN_IS_SPECIAL) && i->content) {
+						nodeSnapshot.stringValue = BDVCStringFromUTF8(bi_node_get_string(i));
+					}
+					if (strcmp(i->name, "Time to Empty") == 0 && !((i->content & BIN_IS_FLOAT) == BIN_IS_FLOAT)) {
+						snapshot->timeToEmpty = (int16_t)(i->content >> 16);
+					}
+					[rows addObject:nodeSnapshot];
+				}
+			}
+		}
+		sectionSnapshot.rows = rows;
+		[sections addObject:sectionSnapshot];
+	}
+	battery_info_unlock();
+
+	snapshot.sections = sections;
+	return snapshot;
 }
 
 void equipDetailCell(UITableViewCell *cell, struct battery_info_node *i) {
@@ -294,8 +433,10 @@ void equipWarningCondition_b(UITableViewCell *equippedCell, NSString *textLabel,
 		new_hvc_owned = false;
 #endif
 
+		BDVCBatteryInfoTableSnapshot *newSnapshot = BDVCCopyBatteryInfoSnapshot(self->batteryInfo);
 		dispatch_async(dispatch_get_main_queue(), ^{
 			self->refreshInFlight = NO;
+			self->batteryInfoSnapshot = newSnapshot;
 
 			if (self->hvc_menu_owned && self->hvc_menu && self->hvc_menu != new_hvc_menu) {
 				free(self->hvc_menu);
@@ -399,6 +540,7 @@ void equipWarningCondition_b(UITableViewCell *equippedCell, NSString *textLabel,
 
 	self.tableView.allowsSelection = YES;
 	batteryInfo = bi;
+	batteryInfoSnapshot = BDVCCopyBatteryInfoSnapshot(bi);
 	refreshQueue = dispatch_queue_create("com.torrekie.Battman.BDVCRefresh", DISPATCH_QUEUE_SERIAL);
 	refreshInFlight = NO;
 	refreshPending = NO;
@@ -474,21 +616,16 @@ void equipWarningCondition_b(UITableViewCell *equippedCell, NSString *textLabel,
 		titleLabel = cell.textLabel.text;
 	}
 
-	char *desc_copy = NULL;
-	battery_info_read_lock();
-	struct battery_info_section *section = battery_info_get_section(*batteryInfo, (int)indexPath.section);
-	if (section) {
-		struct battery_info_node *node = section->data + indexPath.row + pendingLoadOffsets[indexPath.section][indexPath.row];
-		if (node && node->desc) {
-			desc_copy = strdup(node->desc);
+	BDVCBatteryInfoTableSnapshot *snapshot = batteryInfoSnapshot;
+	NSString *desc = nil;
+	if (indexPath.section >= 0 && (NSUInteger)indexPath.section < snapshot.sections.count) {
+		BDVCBatteryInfoSectionSnapshot *section = snapshot.sections[(NSUInteger)indexPath.section];
+		if (indexPath.row >= 0 && (NSUInteger)indexPath.row < section.rows.count) {
+			desc = section.rows[(NSUInteger)indexPath.row].desc;
 		}
 	}
-	battery_info_unlock();
 
-	show_alert([titleLabel UTF8String], desc_copy ? _C(desc_copy) : "", L_OK);
-	if (desc_copy) {
-		free(desc_copy);
-	}
+	show_alert([titleLabel UTF8String], desc ? _C(desc.UTF8String) : "", L_OK);
 	return;
 	// TODO: Implement this
 #if 0
@@ -540,53 +677,39 @@ void equipWarningCondition_b(UITableViewCell *equippedCell, NSString *textLabel,
 
 - (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section {
 	UITableViewHeaderFooterView *header = (UITableViewHeaderFooterView *)view;
-	NSString *title = nil;
-	battery_info_read_lock();
-	struct battery_info_section *sect = battery_info_get_section(*batteryInfo, section);
-	if (sect && sect->data[0].name) {
-		title = _(sect->data[0].name);
+	BDVCBatteryInfoTableSnapshot *snapshot = batteryInfoSnapshot;
+	NSString *title = @"";
+	if (section >= 0 && (NSUInteger)section < snapshot.sections.count) {
+		NSString *rawTitle = snapshot.sections[(NSUInteger)section].title;
+		if (rawTitle) {
+			title = _(rawTitle.UTF8String);
+		}
 	}
-	battery_info_unlock();
-	header.textLabel.text = title ?: @"";
+	header.textLabel.text = title;
 }
 
 - (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section {
-	NSString *footer = nil;
-	battery_info_read_lock();
-	struct battery_info_section *cur = battery_info_get_section(*batteryInfo, section);
-	if (cur && cur->data[0].desc) {
-		footer = _(cur->data[0].desc);
+	BDVCBatteryInfoTableSnapshot *snapshot = batteryInfoSnapshot;
+	if (section < 0 || (NSUInteger)section >= snapshot.sections.count) {
+		return nil;
 	}
-	battery_info_unlock();
-	return footer;
+	NSString *footer = snapshot.sections[(NSUInteger)section].footer;
+	if (!footer) {
+		return nil;
+	}
+	return _(footer.UTF8String);
 }
 
 - (NSInteger)tableView:(id)tv numberOfRowsInSection:(NSInteger)section {
-	battery_info_read_lock();
-	struct battery_info_section *sect = battery_info_get_section(*batteryInfo, section);
-	if (!sect) {
-		battery_info_unlock();
+	BDVCBatteryInfoTableSnapshot *snapshot = batteryInfoSnapshot;
+	if (section < 0 || (NSUInteger)section >= snapshot.sections.count) {
 		return 0;
 	}
-	int                          rows = 0;
-	for (struct battery_info_node *i = sect->data + 1; i->name /*&& (i->content & BIN_SECTION) != BIN_SECTION*/; i++) {
-		if ((i->content & BIN_DETAILS_SHARED) == BIN_DETAILS_SHARED || (i->content && !((i->content & BIN_IS_SPECIAL) == BIN_IS_SPECIAL))) {
-			if ((i->content & 1) != 1 || (i->content & (1 << 5)) != 1 << 5) {
-				pendingLoadOffsets[section][rows] = (unsigned char)((i - sect->data) - rows);
-				rows++;
-			}
-		}
-	}
-	pendingLoadOffsets[section][rows] = 255;
-	battery_info_unlock();
-	return rows;
+	return snapshot.sections[(NSUInteger)section].rows.count;
 }
 
 - (NSInteger)numberOfSectionsInTableView:(id)tv {
-	battery_info_read_lock();
-	int count = battery_info_get_section_count(*batteryInfo);
-	battery_info_unlock();
-	return count;
+	return batteryInfoSnapshot.sections.count;
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tv cellForRowAtIndexPath:(NSIndexPath *)ip {
@@ -605,38 +728,38 @@ void equipWarningCondition_b(UITableViewCell *equippedCell, NSString *textLabel,
 		cell = [[cell_class alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:ident];
 	}
 	
-	battery_info_read_lock();
-	struct battery_info_section *bi_section = battery_info_get_section(*batteryInfo, ip.section);
-	if (!bi_section) {
-		battery_info_unlock();
+	BDVCBatteryInfoTableSnapshot *snapshot = batteryInfoSnapshot;
+	if (ip.section < 0 || (NSUInteger)ip.section >= snapshot.sections.count) {
 		return cell;
 	}
-	struct battery_info_node    *pending_bi = bi_section->data + ip.row + pendingLoadOffsets[ip.section][ip.row];
+	BDVCBatteryInfoSectionSnapshot *sectionSnapshot = snapshot.sections[(NSUInteger)ip.section];
+	if (ip.row < 0 || (NSUInteger)ip.row >= sectionSnapshot.rows.count) {
+		return cell;
+	}
+	BDVCBatteryInfoNodeSnapshot *pending_bi = sectionSnapshot.rows[(NSUInteger)ip.row];
+
 	/* Flags special handler */
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wstring-compare"
-	// ^ We are comparing the pointers, not string contents.
-	if (pending_bi->name == "Flags") {
+	if ([pending_bi.name isEqualToString:@"Flags"]) {
 		SegmentedFlagViewCell *cellf = [tv dequeueReusableCellWithIdentifier:@"FLAGS"];
 		if (!cellf)
 			cellf = [[SegmentedFlagViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:@"FLAGS"];
 
-		cellf.textLabel.text       = _(pending_bi->name);
-		cellf.titleLabel.text      = _(pending_bi->name);
-		cellf.detailTextLabel.text = _(bi_node_get_string(pending_bi));
-		[cellf selectByFlags:gGauge.Flags];
-			if (strlen(gGauge.DeviceName)) {
-				[cellf setBitSetByModel:[NSString stringWithFormat:@"%s", gGauge.DeviceName]];
-			} else {
-				[cellf setBitSetByTargetName];
-			}
-			battery_info_unlock();
-			return cellf;
+		NSString *name = pending_bi.name ?: @"";
+		NSString *detail = BDVCFormattedValueForContent(pending_bi.content, pending_bi.stringValue);
+		cellf.textLabel.text       = _(name.UTF8String);
+		cellf.titleLabel.text      = _(name.UTF8String);
+		cellf.detailTextLabel.text = detail.length ? _(detail.UTF8String) : @"";
+		[cellf selectByFlags:snapshot->gauge.Flags];
+		if (strlen(snapshot->gauge.DeviceName)) {
+			[cellf setBitSetByModel:[NSString stringWithFormat:@"%s", snapshot->gauge.DeviceName]];
+		} else {
+			[cellf setBitSetByTargetName];
 		}
-#pragma clang diagnostic pop
+		return cellf;
+	}
 
 #pragma mark - Warn Conditions
-	equipDetailCell(cell, pending_bi);
+	BDVCEquipDetailCellWithSnapshot(cell, pending_bi);
 	
 	// Workaround for too-long texts in section 0
 //	if (ip.section == 0 && cell.detailTextLabel.text.length > 25) {
@@ -644,23 +767,24 @@ void equipWarningCondition_b(UITableViewCell *equippedCell, NSString *textLabel,
 //		cell.detailTextLabel.lineBreakMode = NSLineBreakByTruncatingTail;
 //	}
 	/* Warning conditions - Only evaluate for specific cells to reduce overhead during scrolling */
-	if (bi_section->context->custom_identifier == BI_GAS_GAUGE_SECTION_ID) {
+	if (sectionSnapshot.customIdentifier == BI_GAS_GAUGE_SECTION_ID) {
 		NSString *cellLabel = cell.textLabel.text;
+		gas_gauge_t gauge = snapshot->gauge;
+		uint16_t remain_cap = gauge.RemainingCapacity;
+		uint16_t full_cap = gauge.FullChargeCapacity;
 		
 		// Only call warning condition check for cells that actually need it
 		if ([cellLabel isEqualToString:_("Remaining Capacity")]) {
 			equipWarningCondition_b(cell, _("Remaining Capacity"), ^warn_condition_t(const char **str) {
 				warn_condition_t code = WARN_NONE;
-				uint16_t         remain_cap, full_cap, design_cap;
-				get_capacity(&remain_cap, &full_cap, &design_cap);
 				if (remain_cap > full_cap) {
 					code = WARN_UNUSUAL;
 					static char errmsg[256];
 					// some Shenzhen battries is spoofing this data to affect internal battery health calculations
 					// But they still had to report a real SoC so that indicating actual conditions.
-					sprintf(errmsg, "%s\n%s: %ld", _C("Unusual Remaining Capacity, a non-genuine battery component may be in use."), _C("Estimated Remaining"), lrintf((float)full_cap * gGauge.StateOfCharge / 100.0f));
+					sprintf(errmsg, "%s\n%s: %ld", _C("Unusual Remaining Capacity, a non-genuine battery component may be in use."), _C("Estimated Remaining"), lrintf((float)full_cap * gauge.StateOfCharge / 100.0f));
 					*str = errmsg;
-				} else if ((gGauge.TrueRemainingCapacity != 0) && (gGauge.RemainingCapacity - 10) > gGauge.TrueRemainingCapacity) {
+				} else if ((gauge.TrueRemainingCapacity != 0) && gauge.RemainingCapacity > (gauge.TrueRemainingCapacity + 10)) {
 					// Battery is lying
 					// TrueRemainingCapacity is calculated by device, not GGIC
 					// So the diff would not exceed 1 normally, we generously allowing 10 here
@@ -676,10 +800,10 @@ void equipWarningCondition_b(UITableViewCell *equippedCell, NSString *textLabel,
 			equipWarningCondition_b(cell, _("Cycle Count"), ^warn_condition_t(const char **str) {
 				warn_condition_t code = WARN_NONE;
 				int              count, design;
-				count  = gGauge.CycleCount;
-				design = gGauge.DesignCycleCount;
+				count  = gauge.CycleCount;
+				design = gauge.DesignCycleCount;
 
-				if (gGauge.DesignCycleCount == 0) {
+				if (gauge.DesignCycleCount == 0) {
 					// according to https://www.apple.com/batteries/service-and-recycling
 					// Pre-iPhone15,3: 500, otherwise 1000
 					// Watch*,* iPad*,*: 1000
@@ -727,18 +851,16 @@ void equipWarningCondition_b(UITableViewCell *equippedCell, NSString *textLabel,
 		} else if ([cellLabel isEqualToString:_("Time to Empty")]) {
 			equipWarningCondition_b(cell, _("Time to Empty"), ^warn_condition_t(const char **str) {
 				warn_condition_t code = WARN_NONE;
-				uint16_t         remain_cap, full_cap, design_cap;
-				int              tte = get_time_to_empty();
-				get_capacity(&remain_cap, &full_cap, &design_cap);
+				int              tte = snapshot->timeToEmpty ?: gauge.TimeToEmpty;
 				/* The most ideal TTE is TTE (Hour) = Capacity (mAh) / Current (mA),
 				 * some user reported their non-genuine battries
 				 * reporting a significant huge number of TTE */
 
 				/* Battery charging, skip */
-				if (gGauge.AverageCurrent > 0)
+				if (gauge.AverageCurrent >= 0)
 					return code;
 
-				int ideal = (remain_cap / abs(gGauge.AverageCurrent)) * 60;
+				int ideal = ((int)remain_cap / abs(gauge.AverageCurrent)) * 60;
 				/* Normally, TI's GG IC would not emulate its TTE bigger than ideal */
 				/* for ensurence, we check if TTE is bigger than 1.5*ideal */
 				if (tte > (ideal * 1.5)) {
@@ -753,7 +875,7 @@ void equipWarningCondition_b(UITableViewCell *equippedCell, NSString *textLabel,
 				/* Non-genuine batteries are likely spoofing some unremarkable data */
 				/* DOD0 is not going to bigger than Qmax normally, but sometimes it do
 				 * exceeds when discharging/charging with adapter attached */
-				if (gGauge.DOD0 > (gGauge.Qmax * 3)) {
+				if (gauge.DOD0 > (gauge.Qmax * 3)) {
 					code = WARN_UNUSUAL;
 					*str = _C("Unusual Depth of Discharge, a non-genuine battery component may be in use.");
 				}
@@ -772,10 +894,7 @@ void equipWarningCondition_b(UITableViewCell *equippedCell, NSString *textLabel,
 	}
 	/* TODO: record 1st-read capacity data in defaults in order to observe battery problems */
 	/* HVC Mode special handler */
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wstring-compare"
-	if (pending_bi->name == "HVC Mode") {
-#pragma clang diagnostic pop
+	if ([pending_bi.name isEqualToString:@"HVC Mode"]) {
 		// Use cached HVC data instead of fetching during cell configuration
 		// This prevents blocking the main thread during scrolling
 		
@@ -827,14 +946,12 @@ void equipWarningCondition_b(UITableViewCell *equippedCell, NSString *textLabel,
 					cell_seg.subDetailLabel.text = [NSString stringWithFormat:@"%d %s", hvc_menu[hvc_index].current, L_MA];
 				}
 
-				battery_info_unlock();
 				return cell_seg;
 			} else {
 				cell.detailTextLabel.text = _("None");
 			}
 		}
 		//        [cell layoutIfNeeded];
-	battery_info_unlock();
 	return cell;
 }
 
@@ -860,38 +977,49 @@ void equipWarningCondition_b(UITableViewCell *equippedCell, NSString *textLabel,
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
 	[tableView deselectRowAtIndexPath:indexPath animated:YES];
+	BDVCBatteryInfoTableSnapshot *snapshot = batteryInfoSnapshot;
+	if (indexPath.section < 0 || (NSUInteger)indexPath.section >= snapshot.sections.count) {
+		return;
+	}
+	BDVCBatteryInfoSectionSnapshot *sectionSnapshot = snapshot.sections[(NSUInteger)indexPath.section];
+	if (indexPath.row < 0 || (NSUInteger)indexPath.row >= sectionSnapshot.rows.count) {
+		return;
+	}
+	BDVCBatteryInfoNodeSnapshot *selectedNode = sectionSnapshot.rows[(NSUInteger)indexPath.row];
+
 	battery_info_write_lock();
-	struct battery_info_section *bi_section = battery_info_get_section(*batteryInfo, indexPath.section);
+	struct battery_info_section *bi_section = batteryInfo ? *batteryInfo : NULL;
+	for (NSInteger section = 0; bi_section && section < indexPath.section; section++) {
+		bi_section = bi_section->next;
+	}
 	if (!bi_section) {
 		battery_info_unlock();
 		return;
 	}
-	struct battery_info_node    *pending_bi = bi_section->data + indexPath.row + pendingLoadOffsets[indexPath.section][indexPath.row];
+	struct battery_info_node    *pending_bi = bi_section->data;
+	for (NSUInteger row = 0; pending_bi->name && row < selectedNode.sourceIndex; row++) {
+		pending_bi++;
+	}
+	if (!pending_bi->name) {
+		battery_info_unlock();
+		return;
+	}
 	if(!(pending_bi->content&BIN_HAS_SUBCELLS)) {
 		battery_info_unlock();
 		return;
 	}
 	int rows=0;
-	int is_hidden=0;
-	NSMutableArray *indexPaths=[NSMutableArray array];
 	for(struct battery_info_node *node=pending_bi+1;node->name&&(node->content&BIN_IS_SUBCELL);node++) {
-		if(node->content&(1<<5))
-			is_hidden=1;
 		node->content^=(1<<5);
 		rows++;
-		[indexPaths addObject:[NSIndexPath indexPathForRow:indexPath.row+rows inSection:indexPath.section]];
 	}
 	if(!rows) {
 		battery_info_unlock();
 		return;
 	}
 	battery_info_unlock();
-	if(is_hidden) {
-		[tableView insertRowsAtIndexPaths:indexPaths withRowAnimation:UITableViewRowAnimationAutomatic];
-	}else{
-		[tableView deleteRowsAtIndexPaths:indexPaths withRowAnimation:UITableViewRowAnimationAutomatic];
-	}
-	//[self updateTableView];
+	batteryInfoSnapshot = BDVCCopyBatteryInfoSnapshot(batteryInfo);
+	[tableView reloadData];
 }
 
 @end

--- a/Battman/BatteryInfoViewController.m
+++ b/Battman/BatteryInfoViewController.m
@@ -97,6 +97,9 @@ enum sections_batteryinfo {
 @implementation BatteryInfoViewController {
 	CGFloat _cachedIconCornerRadius;
 	BOOL _cachedIconCornerRadiusValid;
+	dispatch_queue_t _refreshQueue;
+	BOOL _refreshInFlight;
+	BOOL _refreshPending;
 }
 
 - (NSString *)title {
@@ -110,7 +113,6 @@ enum sections_batteryinfo {
 		// Never mode - don't update automatically
 		return;
 	}
-	NSLog(@"batteryStatusDidUpdate: interval: %f", interval);
 	// Only call super (which calls updateTableView) in auto mode
 	// In timer mode, the timer handles calling updateTableView directly
 	if (interval == 0.0f) {
@@ -119,6 +121,36 @@ enum sections_batteryinfo {
 		DBGLOG(@"BIVC: batteryStatusDidUpdate");
 		[super batteryStatusDidUpdate];
 	}
+}
+
+- (void)_startQueuedRefresh {
+	if (_refreshInFlight) {
+		_refreshPending = YES;
+		return;
+	}
+
+	if (!self.refreshControl.refreshing) {
+		[self.refreshControl beginRefreshing];
+	}
+	_refreshInFlight = YES;
+	dispatch_async(_refreshQueue, ^{
+		battery_info_update(&self->batteryInfo);
+
+		dispatch_async(dispatch_get_main_queue(), ^{
+			self->_refreshInFlight = NO;
+			if ([self isViewLoaded] && self.view.window) {
+				[self.tableView reloadData];
+			}
+			[self.refreshControl endRefreshing];
+
+			if (self->_refreshPending) {
+				if (!(self.tableView.dragging || self.tableView.decelerating || self.tableView.tracking)) {
+					self->_refreshPending = NO;
+					[self _startQueuedRefresh];
+				}
+			}
+		});
+	});
 }
 
 - (void)viewDidLoad {
@@ -219,6 +251,10 @@ enum sections_batteryinfo {
 	DBGLOG(@"[PERF] BatteryInfoViewController init DONE: %.3fms", (CFAbsoluteTimeGetCurrent() - initStart) * 1000);
 #endif
 	
+	_refreshQueue = dispatch_queue_create("com.torrekie.Battman.BIVCRefresh", DISPATCH_QUEUE_SERIAL);
+	_refreshInFlight = NO;
+	_refreshPending = NO;
+
 	if (@available(iOS 13.0, *))
 		return [super initWithStyle:UITableViewStyleInsetGrouped];
 	else
@@ -441,17 +477,33 @@ enum sections_batteryinfo {
 }
 
 - (void)updateTableView {
-	DBGLOG(@"BIVC: updateTableView");
-	[self.refreshControl beginRefreshing];
-
-	dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
-	      battery_info_update(&self->batteryInfo);
-
+	if (![NSThread isMainThread]) {
 		dispatch_async(dispatch_get_main_queue(), ^{
-	      	[self.tableView reloadData];
-			[self.refreshControl endRefreshing];
+			[self updateTableView];
 		});
-	});
+		return;
+	}
+
+	DBGLOG(@"BIVC: updateTableView");
+	if (self.tableView.dragging || self.tableView.decelerating || self.tableView.tracking) {
+		_refreshPending = YES;
+		return;
+	}
+	[self _startQueuedRefresh];
+}
+
+- (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView {
+	if (_refreshPending && !_refreshInFlight) {
+		_refreshPending = NO;
+		[self _startQueuedRefresh];
+	}
+}
+
+- (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate {
+	if (!decelerate && _refreshPending && !_refreshInFlight) {
+		_refreshPending = NO;
+		[self _startQueuedRefresh];
+	}
 }
 
 - (void)dealloc {

--- a/Battman/BatteryInfoViewController.m
+++ b/Battman/BatteryInfoViewController.m
@@ -100,10 +100,17 @@ enum sections_batteryinfo {
 	dispatch_queue_t _refreshQueue;
 	BOOL _refreshInFlight;
 	BOOL _refreshPending;
+	BOOL _refreshSuspended;
+	NSUInteger _refreshGeneration;
+	NSUInteger _refreshInFlightGeneration;
 }
 
 - (NSString *)title {
-    return _("Battman");
+	return _("Battman");
+}
+
+- (BOOL)_canScheduleRefresh {
+	return !_refreshSuspended && [UIApplication sharedApplication].applicationState != UIApplicationStateBackground;
 }
 
 - (void)batteryStatusDidUpdate:(NSDictionary *)info {
@@ -124,8 +131,16 @@ enum sections_batteryinfo {
 }
 
 - (void)_startQueuedRefresh {
+	if (![self _canScheduleRefresh]) {
+		_refreshPending = NO;
+		[self.refreshControl endRefreshing];
+		return;
+	}
+
 	if (_refreshInFlight) {
-		_refreshPending = YES;
+		if (_refreshInFlightGeneration != _refreshGeneration) {
+			_refreshPending = YES;
+		}
 		return;
 	}
 
@@ -133,11 +148,24 @@ enum sections_batteryinfo {
 		[self.refreshControl beginRefreshing];
 	}
 	_refreshInFlight = YES;
+	NSUInteger generation = _refreshGeneration;
+	_refreshInFlightGeneration = generation;
 	dispatch_async(_refreshQueue, ^{
 		battery_info_update(&self->batteryInfo);
 
 		dispatch_async(dispatch_get_main_queue(), ^{
 			self->_refreshInFlight = NO;
+			if (generation != self->_refreshGeneration || ![self _canScheduleRefresh]) {
+				BOOL shouldRestart = self->_refreshPending && [self _canScheduleRefresh] &&
+					!(self.tableView.dragging || self.tableView.decelerating || self.tableView.tracking);
+				self->_refreshPending = NO;
+				[self.refreshControl endRefreshing];
+				if (shouldRestart) {
+					[self _startQueuedRefresh];
+				}
+				return;
+			}
+
 			if ([self isViewLoaded] && self.view.window) {
 				[self.tableView reloadData];
 			}
@@ -153,6 +181,20 @@ enum sections_batteryinfo {
 	});
 }
 
+- (void)applicationDidEnterBackground:(NSNotification *)notification {
+	_refreshSuspended = YES;
+	_refreshPending = NO;
+	_refreshGeneration++;
+	if (!_refreshInFlight) {
+		[self.refreshControl endRefreshing];
+	}
+}
+
+- (void)applicationWillEnterForeground:(NSNotification *)notification {
+	_refreshSuspended = NO;
+	_refreshGeneration++;
+}
+
 - (void)viewDidLoad {
     [super viewDidLoad];
 	
@@ -164,6 +206,10 @@ enum sections_batteryinfo {
     UIRefreshControl *refreshControl = [[UIRefreshControl alloc] init];
     [refreshControl addTarget:self action:@selector(updateTableView) forControlEvents:UIControlEventValueChanged];
     self.refreshControl = refreshControl;
+
+	NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
+	[center addObserver:self selector:@selector(applicationDidEnterBackground:) name:UIApplicationDidEnterBackgroundNotification object:nil];
+	[center addObserver:self selector:@selector(applicationWillEnterForeground:) name:UIApplicationWillEnterForegroundNotification object:nil];
 
     // Copyright text
     UILabel *copyright;
@@ -254,6 +300,9 @@ enum sections_batteryinfo {
 	_refreshQueue = dispatch_queue_create("com.torrekie.Battman.BIVCRefresh", DISPATCH_QUEUE_SERIAL);
 	_refreshInFlight = NO;
 	_refreshPending = NO;
+	_refreshSuspended = [UIApplication sharedApplication].applicationState == UIApplicationStateBackground;
+	_refreshGeneration = 0;
+	_refreshInFlightGeneration = 0;
 
 	if (@available(iOS 13.0, *))
 		return [super initWithStyle:UITableViewStyleInsetGrouped];
@@ -485,6 +534,12 @@ enum sections_batteryinfo {
 	}
 
 	DBGLOG(@"BIVC: updateTableView");
+	if (![self _canScheduleRefresh]) {
+		_refreshPending = NO;
+		[self.refreshControl endRefreshing];
+		return;
+	}
+
 	if (self.tableView.dragging || self.tableView.decelerating || self.tableView.tracking) {
 		_refreshPending = YES;
 		return;
@@ -507,6 +562,7 @@ enum sections_batteryinfo {
 }
 
 - (void)dealloc {
+	[[NSNotificationCenter defaultCenter] removeObserver:self];
 	for(struct battery_info_section *sect=batteryInfo;sect;) {
 		struct battery_info_section *next=sect->next;
 		for (struct battery_info_node *i = sect->data; i->name; i++) {

--- a/Battman/battery_utils/battery_info.c
+++ b/Battman/battery_utils/battery_info.c
@@ -8,6 +8,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <pthread.h>
 #include <unistd.h>
 
 #include <CoreFoundation/CFArray.h>
@@ -27,6 +28,20 @@ const char *bin_unit_strings[] = {
 	_C("℃"), _C("%"), _C("mA"), _C("mAh"), _C("mV"), _C("mW"), _C("min"),
 	_C("Hr") // Do not modify, thats how Texas Instruments documented
 };
+
+static pthread_rwlock_t gBatteryInfoLock = PTHREAD_RWLOCK_INITIALIZER;
+
+void battery_info_read_lock(void) {
+	pthread_rwlock_rdlock(&gBatteryInfoLock);
+}
+
+void battery_info_write_lock(void) {
+	pthread_rwlock_wrlock(&gBatteryInfoLock);
+}
+
+void battery_info_unlock(void) {
+	pthread_rwlock_unlock(&gBatteryInfoLock);
+}
 
 struct battery_info_node main_battery_template[] = {
 	{ _C("Gas Gauge (Basic)"), _C("All Gas Gauge metrics are dynamically retrieved from the onboard sensor array in real time. Should anomalies be detected in specific readings, this may indicate the presence of unauthorized components or require diagnostics through Apple Authorised Service Provider."), DEFINE_SECTION(10000) },
@@ -532,6 +547,7 @@ void battery_info_poll(struct battery_info_section **head) {
 }
 
 void battery_info_update(struct battery_info_section **head) {
+	battery_info_write_lock();
 	battery_info_poll(head);
 	int retry=1;
 	while(*head&&retry) {
@@ -553,6 +569,7 @@ void battery_info_update(struct battery_info_section **head) {
 			}
 		}
 	}
+	battery_info_unlock();
 }
 
 struct battery_info_section *battery_info_get_section(struct battery_info_section *head, long n) {

--- a/Battman/battery_utils/battery_info.h
+++ b/Battman/battery_utils/battery_info.h
@@ -171,6 +171,9 @@ char *bi_node_ensure_string(struct battery_info_node *node, int identifier,
                             uint64_t length);
 char *bi_node_get_string(struct battery_info_node *node);
 void bi_node_free_string(struct battery_info_node *node);
+void battery_info_read_lock(void);
+void battery_info_write_lock(void);
+void battery_info_unlock(void);
 void battery_info_update(struct battery_info_section **head);
 int battery_info_get_section_count(struct battery_info_section *head);
 struct battery_info_section *battery_info_get_section(struct battery_info_section *head, long section);


### PR DESCRIPTION
## Summary
- add battery info RW lock API and protect read/write call sites
- serialize refresh work on dedicated queues in battery info/details controllers
- coalesce burst updates and defer queued refresh while user is scrolling
- free owned HVC buffers safely to avoid stale pointer/memory leaks

## Why
- addresses races/crash potentials around battery info mutation
- reduces UI jank from redundant reload bursts during frequent updates

## Testing
- xcodebuild -project Battman.xcodeproj -scheme Battman -configuration Debug -sdk iphoneos CODE_SIGNING_ALLOWED=NO build