### PR TITLE
Fix accessory and UPS battery memory-safety crashes

### DIFF
--- a/Battman/UPSMonitor-new.m
+++ b/Battman/UPSMonitor-new.m
@@ -9,7 +9,7 @@
 #import "UPSMonitor.h"
 
 #include <pthread/pthread.h>
-#include <syslog.h>
+#include <unistd.h>
 #import <UIKit/UIKit.h>
 
 UPSDeviceSet *gAllUPSDevices = NULL;
@@ -19,25 +19,25 @@ UPSDeviceSet *gAllUPSDevices = NULL;
 // ---------------------------------------------------------------------------
 
 static bool UPSWatching = false;
-
-static dispatch_queue_t gDevicesQueue;        // serial queue to protect gAllUPSDevices
-
 static pthread_t gUPSWatchThread = 0;         // watch thread (joinable)
+static bool gWatchThreadExited = false;
+static bool gWatchThreadStarting = false;
+static bool gWatchThreadReady = false;
 static CFRunLoopRef gBackgroundRunLoop = NULL;
 static IONotificationPortRef gNotifyPort = NULL;
 static io_iterator_t gAddedIter = MACH_PORT_NULL;
 
 static bool gTerminationInProgress = false;
-
-// queue used for teardown work (so we do not block main thread)
-static dispatch_queue_t gTeardownQueue;
+static bool gNotificationsPaused = false;
 
 // (Full file content, with modifications and added helper functions)
 
 // --- additions at top of file (new global lock & helper prototypes) ---
 static pthread_mutex_t gAllUPSDevicesLock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t gWatchLifecycleLock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t gWatchStateCondition = PTHREAD_COND_INITIALIZER;
 
-static bool UPSDeviceSetContainsByID(UPSDeviceSet *set, uint64_t regID);
+static bool AllUPSDevicesContainsByID(uint64_t regID);
 static void SetupPluginAndEventSourceForDevice(UPSDataRef upsDataRef, io_service_t upsDevice);
 static void TeardownDeviceRuntime(UPSDataRef upsDataRef); // remove sources/timers/notification/plugin but keep CF properties
 static void RecreateMonitoringForExistingDevices(void); // run on background runloop to reattach existing devices
@@ -57,6 +57,10 @@ static UPSDeviceSet *UPSDeviceSetCreate(void) {
 	if (!set) return NULL;
 	set->capacity = 1;
 	set->items    = calloc(set->capacity, sizeof(UPSDataRef));
+	if (!set->items) {
+		free(set);
+		return NULL;
+	}
 	return set;
 }
 
@@ -66,196 +70,264 @@ static void UPSDeviceSetDestroy(UPSDeviceSet *set) {
 	free(set->items);
 	free(set);
 }
-
-// Returns true if already present
-static bool UPSDeviceSetContains(UPSDeviceSet *set, UPSDataRef ptr) {
-	bool ret = false;
-	if (!set) return false;
-	pthread_mutex_lock(&gAllUPSDevicesLock);
-	for (size_t i = 0; i < set->count; i++) {
-		if (set->items[i]->regID == ptr->regID) { ret = true; break; }
+static UPSDataRef UPSDataRetain(UPSDataRef upsDataRef) {
+	if (upsDataRef) {
+		__atomic_add_fetch(&upsDataRef->retainCount, 1, __ATOMIC_RELAXED);
 	}
-	pthread_mutex_unlock(&gAllUPSDevicesLock);
-	return ret;
+	return upsDataRef;
 }
 
-// New: check existence by regID
-static bool UPSDeviceSetContainsByID(UPSDeviceSet *set, uint64_t regID) {
-	bool ret = false;
-	if (!set) return false;
-	pthread_mutex_lock(&gAllUPSDevicesLock);
-	for (size_t i = 0; i < set->count; i++) {
-		if (set->items[i]->regID == regID) { ret = true; break; }
-	}
-	pthread_mutex_unlock(&gAllUPSDevicesLock);
-	return ret;
+static void UPSDataRelease(UPSDataRef upsDataRef);
+
+typedef struct UPSRuntimeResources {
+	IOUPSPlugInInterface **plugin;
+	io_object_t notification;
+	UPSDataRef notificationOwner;
+	CFRunLoopSourceRef eventSource;
+	CFRunLoopTimerRef eventTimer;
+} UPSRuntimeResources;
+
+static UPSRuntimeResources UPSDetachRuntimeLocked(UPSDataRef upsDataRef) {
+	UPSRuntimeResources runtime = {
+		.plugin = upsDataRef->upsPlugInInterface,
+		.notification = upsDataRef->notification,
+		.notificationOwner = upsDataRef->notification != MACH_PORT_NULL ? upsDataRef : NULL,
+		.eventSource = upsDataRef->upsEventSource,
+		.eventTimer = upsDataRef->upsEventTimer,
+	};
+	upsDataRef->upsPlugInInterface = NULL;
+	upsDataRef->notification = MACH_PORT_NULL;
+	upsDataRef->upsEventSource = NULL;
+	upsDataRef->upsEventTimer = NULL;
+	return runtime;
 }
 
-// Add ptr if not already in the set
-static bool UPSDeviceSetAdd(UPSDeviceSet *set, UPSDataRef ptr) {
-	if (!set || !ptr) return false;
-	pthread_mutex_lock(&gAllUPSDevicesLock);
-	// check existence by regID
-	for (size_t i = 0; i < set->count; i++) {
-		if (set->items[i]->regID == ptr->regID) {
-			pthread_mutex_unlock(&gAllUPSDevicesLock);
-			return false;
-		}
+static void UPSReleaseRuntime(UPSRuntimeResources runtime) {
+	if (runtime.notification != MACH_PORT_NULL) {
+		IOObjectRelease(runtime.notification);
 	}
-	if (set->count == set->capacity) {
-		size_t newCap = set->capacity * 2;
-		UPSDataRef *newArr = realloc(set->items, newCap * sizeof(UPSDataRef));
-		if (!newArr) {
-			pthread_mutex_unlock(&gAllUPSDevicesLock);
-			return false;
-		}
-		set->items    = newArr;
-		set->capacity = newCap;
+	if (runtime.eventSource) {
+		CFRunLoopSourceInvalidate(runtime.eventSource);
+		CFRelease(runtime.eventSource);
 	}
-	set->items[set->count++] = ptr;
-	pthread_mutex_unlock(&gAllUPSDevicesLock);
-	return true;
+	if (runtime.eventTimer) {
+		CFRunLoopTimerInvalidate(runtime.eventTimer);
+		CFRelease(runtime.eventTimer);
+	}
+	if (runtime.plugin) {
+		(*runtime.plugin)->Release(runtime.plugin);
+	}
+	if (runtime.notificationOwner) {
+		UPSDataRelease(runtime.notificationOwner);
+	}
 }
 
-// Remove ptr if present; shifts tail elements down
-static bool UPSDeviceSetRemove(UPSDeviceSet *set, UPSDataRef ptr) {
-	if (!set || !ptr) return false;
-	bool ret = false;
-	pthread_mutex_lock(&gAllUPSDevicesLock);
-	for (size_t i = 0; i < set->count; i++) {
-		if (set->items[i]->regID == ptr->regID) {
-			memmove(&set->items[i],
-					&set->items[i+1],
-					(set->count - i - 1) * sizeof(UPSDataRef));
-			set->count--;
-			ret = true;
-			break;
-		}
-	}
-	pthread_mutex_unlock(&gAllUPSDevicesLock);
-	return ret;
+static void UPSDataDestroy(UPSDataRef upsDataRef) {
+	TeardownDeviceRuntime(upsDataRef);
+	if (upsDataRef->upsProperties) CFRelease(upsDataRef->upsProperties);
+	if (upsDataRef->upsCapabilities) CFRelease(upsDataRef->upsCapabilities);
+	if (upsDataRef->upsEvent) CFRelease(upsDataRef->upsEvent);
+	free(upsDataRef);
 }
 
-// Number of items
-static size_t UPSDeviceSetCount(UPSDeviceSet *set) {
-	size_t c = 0;
-	if (!set) return 0;
-	pthread_mutex_lock(&gAllUPSDevicesLock);
-	c = set->count;
-	pthread_mutex_unlock(&gAllUPSDevicesLock);
-	return c;
+static void UPSDataRelease(UPSDataRef upsDataRef) {
+	if (upsDataRef &&
+	    __atomic_sub_fetch(&upsDataRef->retainCount, 1, __ATOMIC_ACQ_REL) == 0) {
+		UPSDataDestroy(upsDataRef);
+	}
 }
 
-// Copy all items into user-supplied buffer (must be at least count() in size)
-static void UPSDeviceSetGetAll(UPSDeviceSet *set, UPSDataRef *outBuffer) {
-	if (!set || !outBuffer) return;
+static bool AllUPSDevicesContainsByID(uint64_t regID) {
+	bool contains = false;
 	pthread_mutex_lock(&gAllUPSDevicesLock);
-	memcpy(outBuffer, set->items, set->count * sizeof(UPSDataRef));
-	pthread_mutex_unlock(&gAllUPSDevicesLock);
-}
-
-UPSDataRef UPSDeviceMatchingVendorProduct(int vid, int pid) {
-	UPSDataRef ret = NULL;
-	if (!gAllUPSDevices || gAllUPSDevices->count == 0) {
-		DBGLOG(@"[UPSMonitor] no UPS devices yet");
-		return NULL;
-	}
-	if (vid == 0 || pid == 0) {
-		return NULL;
-	}
-	
-	pthread_mutex_lock(&gAllUPSDevicesLock);
-	for (size_t i = 0; i < gAllUPSDevices->count; i++) {
-		UPSDataRef d = gAllUPSDevices->items[i];
-		
-		SInt32 vendor, product;
-		CFNumberRef number;
-		if (d->upsProperties) {
-			number = CFDictionaryGetValue(d->upsProperties, CFSTR("Vendor ID"));
-			if (!number || !CFNumberGetValue(number, kCFNumberSInt32Type, &vendor)) {
-				continue;
-			}
-			number = CFDictionaryGetValue(d->upsProperties, CFSTR("Product ID"));
-			if (!number || !CFNumberGetValue(number, kCFNumberSInt32Type, &product)) {
-				continue;
-			}
-			if ((vendor == vid) && (product == pid)) {
-				ret = d;
+	if (gAllUPSDevices) {
+		for (size_t i = 0; i < gAllUPSDevices->count; i++) {
+			if (gAllUPSDevices->items[i]->regID == regID) {
+				contains = true;
 				break;
 			}
 		}
 	}
 	pthread_mutex_unlock(&gAllUPSDevicesLock);
-	return ret;
+	return contains;
 }
 
-// Free per-device runtime objects and the structure. This function must be safe to call from any thread.
-// It will schedule runloop removals on gBackgroundRunLoop if needed.
-static void
-FreeUPSData(UPSDataRef upsDataRef)
-{
-	if (upsDataRef == NULL) return;
-	
-	// Remove runloop source/timer on the background runloop (if that runloop exists)
-	if (upsDataRef->upsEventSource || upsDataRef->upsEventTimer) {
-		if (gBackgroundRunLoop) {
-			// schedule removal on the background runloop to be safe
-			CFRetain(upsDataRef); // keep until removal block runs
-			CFRunLoopPerformBlock(gBackgroundRunLoop, kCFRunLoopDefaultMode, ^{
-				if (upsDataRef->upsEventSource) {
-					CFRunLoopRemoveSource(gBackgroundRunLoop, upsDataRef->upsEventSource, kCFRunLoopDefaultMode);
-					CFRelease(upsDataRef->upsEventSource);
-					upsDataRef->upsEventSource = NULL;
+// Transfers the caller's initial reference to the global set on success.
+static bool AllUPSDevicesAdd(UPSDataRef upsDataRef) {
+	bool added = false;
+	if (!upsDataRef) return false;
+	pthread_mutex_lock(&gAllUPSDevicesLock);
+	if (!gTerminationInProgress) {
+		if (!gAllUPSDevices) gAllUPSDevices = UPSDeviceSetCreate();
+		if (gAllUPSDevices) {
+			bool duplicate = false;
+			for (size_t i = 0; i < gAllUPSDevices->count; i++) {
+				if (gAllUPSDevices->items[i]->regID == upsDataRef->regID) {
+					duplicate = true;
+					break;
 				}
-				if (upsDataRef->upsEventTimer) {
-					CFRunLoopRemoveTimer(gBackgroundRunLoop, upsDataRef->upsEventTimer, kCFRunLoopDefaultMode);
-					CFRelease(upsDataRef->upsEventTimer);
-					upsDataRef->upsEventTimer = NULL;
-				}
-				CFRelease(upsDataRef);
-			});
-			CFRunLoopWakeUp(gBackgroundRunLoop);
-		} else {
-			// no background runloop: try to remove from current runloop (best-effort)
-			if (upsDataRef->upsEventSource) {
-				CFRunLoopRemoveSource(CFRunLoopGetCurrent(), upsDataRef->upsEventSource, kCFRunLoopDefaultMode);
-				CFRelease(upsDataRef->upsEventSource);
-				upsDataRef->upsEventSource = NULL;
 			}
-			if (upsDataRef->upsEventTimer) {
-				CFRunLoopRemoveTimer(CFRunLoopGetCurrent(), upsDataRef->upsEventTimer, kCFRunLoopDefaultMode);
-				CFRelease(upsDataRef->upsEventTimer);
-				upsDataRef->upsEventTimer = NULL;
+			if (!duplicate) {
+				if (gAllUPSDevices->count < gAllUPSDevices->capacity) {
+					added = true;
+				} else {
+					size_t newCapacity = gAllUPSDevices->capacity
+					    ? gAllUPSDevices->capacity * 2 : 1;
+					UPSDataRef *items = realloc(gAllUPSDevices->items,
+					    newCapacity * sizeof(*items));
+					if (items) {
+						gAllUPSDevices->items = items;
+						gAllUPSDevices->capacity = newCapacity;
+						added = true;
+					}
+				}
+				if (added) gAllUPSDevices->items[gAllUPSDevices->count++] = upsDataRef;
 			}
 		}
 	}
-	
-	if (upsDataRef->upsPlugInInterface) {
-		// safe guard: only release if non-null
-		(*upsDataRef->upsPlugInInterface)->Release(upsDataRef->upsPlugInInterface);
-		upsDataRef->upsPlugInInterface = NULL;
+	pthread_mutex_unlock(&gAllUPSDevicesLock);
+	return added;
+}
+
+// Transfers the set's reference to the caller on success.
+static bool AllUPSDevicesRemove(UPSDataRef upsDataRef) {
+	bool removed = false;
+	if (!upsDataRef) return false;
+	pthread_mutex_lock(&gAllUPSDevicesLock);
+	if (gAllUPSDevices) {
+		for (size_t i = 0; i < gAllUPSDevices->count; i++) {
+			if (gAllUPSDevices->items[i] == upsDataRef) {
+				memmove(&gAllUPSDevices->items[i], &gAllUPSDevices->items[i + 1],
+				    (gAllUPSDevices->count - i - 1) * sizeof(UPSDataRef));
+				gAllUPSDevices->count--;
+				removed = true;
+				break;
+			}
+		}
 	}
-	
-	if (upsDataRef->notification != MACH_PORT_NULL) {
-		IOObjectRelease(upsDataRef->notification);
-		upsDataRef->notification = MACH_PORT_NULL;
+	pthread_mutex_unlock(&gAllUPSDevicesLock);
+	return removed;
+}
+
+// Returns retained device references from one lock-protected snapshot.
+static UPSDataRef *AllUPSDevicesCopy(size_t *outCount) {
+	UPSDataRef *items = NULL;
+	*outCount = 0;
+	pthread_mutex_lock(&gAllUPSDevicesLock);
+	if (gAllUPSDevices && gAllUPSDevices->count) {
+		items = calloc(gAllUPSDevices->count, sizeof(*items));
+		if (items) {
+			*outCount = gAllUPSDevices->count;
+			for (size_t i = 0; i < *outCount; i++) {
+				items[i] = UPSDataRetain(gAllUPSDevices->items[i]);
+			}
+		}
 	}
-	
-	// release CF objects (properties/capabilities/event) - these were retained when created/assigned
-	if (upsDataRef->upsProperties) {
-		CFRelease(upsDataRef->upsProperties);
-		upsDataRef->upsProperties = NULL;
+	pthread_mutex_unlock(&gAllUPSDevicesLock);
+	return items;
+}
+
+// Detaches the set atomically so only one shutdown path owns its references.
+static UPSDeviceSet *AllUPSDevicesTake(void) {
+	pthread_mutex_lock(&gAllUPSDevicesLock);
+	UPSDeviceSet *set = gAllUPSDevices;
+	gAllUPSDevices = NULL;
+	pthread_mutex_unlock(&gAllUPSDevicesLock);
+	return set;
+}
+
+bool UPSCopyBatterySnapshot(int vid, int pid, UPSBatterySnapshot *snapshot) {
+	if (!snapshot) return false;
+	memset(snapshot, 0, sizeof(*snapshot));
+	if (vid == 0 || pid == 0) return false;
+
+	bool found = false;
+	pthread_mutex_lock(&gAllUPSDevicesLock);
+	if (gAllUPSDevices) {
+		for (size_t i = 0; i < gAllUPSDevices->count; i++) {
+			UPSDataRef device = gAllUPSDevices->items[i];
+			if (!device->upsProperties ||
+			    CFGetTypeID(device->upsProperties) != CFDictionaryGetTypeID()) continue;
+			SInt32 vendor = 0;
+			SInt32 product = 0;
+			CFNumberRef number = CFDictionaryGetValue(device->upsProperties, CFSTR("Vendor ID"));
+			if (!number || CFGetTypeID(number) != CFNumberGetTypeID() ||
+			    !CFNumberGetValue(number, kCFNumberSInt32Type, &vendor)) continue;
+			number = CFDictionaryGetValue(device->upsProperties, CFSTR("Product ID"));
+			if (!number || CFGetTypeID(number) != CFNumberGetTypeID() ||
+			    !CFNumberGetValue(number, kCFNumberSInt32Type, &product)) continue;
+			if (vendor != vid || product != pid) continue;
+
+			snapshot->battery = ups_battery_info(device);
+			if (device->upsCapabilities &&
+			    CFGetTypeID(device->upsCapabilities) == CFSetGetTypeID()) {
+				CFIndex count = CFSetGetCount(device->upsCapabilities);
+				for (CFIndex cell = 0; cell < count; cell++) {
+					CFStringRef key = CFStringCreateWithFormat(kCFAllocatorDefault, NULL,
+					    CFSTR("Cell %ld Voltage"), cell);
+					if (!key) break;
+					bool present = CFSetContainsValue(device->upsCapabilities, key);
+					CFRelease(key);
+					if (!present) break;
+					snapshot->cell_count++;
+				}
+			}
+			found = true;
+			break;
+		}
 	}
-	if (upsDataRef->upsCapabilities) {
-		CFRelease(upsDataRef->upsCapabilities);
-		upsDataRef->upsCapabilities = NULL;
+	pthread_mutex_unlock(&gAllUPSDevicesLock);
+	return found;
+}
+
+static void TeardownDeviceRuntime(UPSDataRef upsDataRef) {
+	if (!upsDataRef) return;
+	pthread_mutex_lock(&gAllUPSDevicesLock);
+	UPSRuntimeResources runtime = UPSDetachRuntimeLocked(upsDataRef);
+	pthread_mutex_unlock(&gAllUPSDevicesLock);
+	UPSReleaseRuntime(runtime);
+}
+
+static void FreeUPSData(UPSDataRef upsDataRef) {
+	if (!upsDataRef) return;
+	pthread_mutex_lock(&gAllUPSDevicesLock);
+	upsDataRef->removed = true;
+	UPSRuntimeResources runtime = UPSDetachRuntimeLocked(upsDataRef);
+	pthread_mutex_unlock(&gAllUPSDevicesLock);
+	UPSDataRelease(upsDataRef);
+	UPSReleaseRuntime(runtime);
+}
+
+static void AllUPSDevicesRemoveMissing(CFSetRef presentRegistryIDs) {
+	if (!presentRegistryIDs) return;
+	UPSDataRef *removed = NULL;
+	size_t removedCount = 0;
+
+	pthread_mutex_lock(&gAllUPSDevicesLock);
+	if (gAllUPSDevices && gAllUPSDevices->count) {
+		removed = calloc(gAllUPSDevices->count, sizeof(*removed));
+		if (removed) {
+			for (size_t i = 0; i < gAllUPSDevices->count;) {
+				uint64_t regID = gAllUPSDevices->items[i]->regID;
+				CFNumberRef number = CFNumberCreate(kCFAllocatorDefault,
+				    kCFNumberSInt64Type, &regID);
+				bool present = !number || CFSetContainsValue(presentRegistryIDs, number);
+				if (number) CFRelease(number);
+				if (present) {
+					i++;
+					continue;
+				}
+				removed[removedCount++] = gAllUPSDevices->items[i];
+				memmove(&gAllUPSDevices->items[i], &gAllUPSDevices->items[i + 1],
+				    (gAllUPSDevices->count - i - 1) * sizeof(UPSDataRef));
+				gAllUPSDevices->count--;
+			}
+		}
 	}
-	if (upsDataRef->upsEvent) {
-		CFRelease(upsDataRef->upsEvent);
-		upsDataRef->upsEvent = NULL;
-	}
-	
-	free(upsDataRef);
+	pthread_mutex_unlock(&gAllUPSDevicesLock);
+
+	for (size_t i = 0; i < removedCount; i++) FreeUPSData(removed[i]);
+	free(removed);
 }
 
 // Device interest notifications come here (called by IOKit)
@@ -266,11 +338,8 @@ void DeviceNotification(void *refCon, io_service_t service, natural_t messageTyp
 	}
 	
 	if (messageType == kIOMessageServiceIsTerminated) {
-		// Remove from set and free
-		if (gAllUPSDevices) {
-			UPSDeviceSetRemove(gAllUPSDevices, upsData);
-		}
-		FreeUPSData(upsData);
+		// The set reference belongs to whichever removal path wins.
+		if (AllUPSDevicesRemove(upsData)) FreeUPSData(upsData);
 	}
 }
 
@@ -297,8 +366,14 @@ static void SetupPluginAndEventSourceForDevice(UPSDataRef upsDataRef, io_service
 	IOUPSPlugInInterface_v140 **   upsPlugInInterface  = NULL;
 	SInt32                    score           = 0;
 	IOReturn                  kr;
-	HRESULT                   result;
+	HRESULT                   result          = E_NOINTERFACE;
 	CFTypeRef typeRef = NULL;
+	CFRunLoopSourceRef newSource = NULL;
+	CFRunLoopTimerRef newTimer = NULL;
+	CFDictionaryRef newProps = NULL;
+	CFSetRef newCaps = NULL;
+	CFDictionaryRef newEvent = NULL;
+	io_object_t newNotification = MACH_PORT_NULL;
 	
 	kr = IOCreatePlugInInterfaceForService(upsDevice, kIOUPSPlugInTypeID, kIOCFPlugInInterfaceID, &plugInInterface, &score);
 	if (kr != kIOReturnSuccess || !plugInInterface) {
@@ -325,152 +400,118 @@ static void SetupPluginAndEventSourceForDevice(UPSDataRef upsDataRef, io_service
 		}
 	}
 	
-	// We have an async event source (or timer)
+	// Build runtime state in locals so teardown never races partially initialized fields.
 	if (typeRef) {
-		// Process and attach to the background runloop
-		ProcessUPSEventSource(typeRef, &upsDataRef->upsEventTimer, &upsDataRef->upsEventSource);
-		
-		// Attach to background runloop safely (we expect this function to be called on the background runloop,
-		// but guard just in case)
-		if (gBackgroundRunLoop && (upsDataRef->upsEventSource || upsDataRef->upsEventTimer)) {
-			if (upsDataRef->upsEventSource) {
-				CFRunLoopAddSource(gBackgroundRunLoop, upsDataRef->upsEventSource, kCFRunLoopDefaultMode);
-			}
-			if (upsDataRef->upsEventTimer) {
-				CFRunLoopAddTimer(gBackgroundRunLoop, upsDataRef->upsEventTimer, kCFRunLoopDefaultMode);
+		if (CFGetTypeID(typeRef) == CFArrayGetTypeID()) {
+			CFArrayRef sources = (CFArrayRef)typeRef;
+			for (CFIndex i = 0; i < CFArrayGetCount(sources); i++) {
+				ProcessUPSEventSource(CFArrayGetValueAtIndex(sources, i),
+				    &newTimer, &newSource);
 			}
 		} else {
-			// best-effort: add to current runloop
-			if (upsDataRef->upsEventSource) {
-				CFRunLoopAddSource(CFRunLoopGetCurrent(), upsDataRef->upsEventSource, kCFRunLoopDefaultMode);
-			}
-			if (upsDataRef->upsEventTimer) {
-				CFRunLoopAddTimer(CFRunLoopGetCurrent(), upsDataRef->upsEventTimer, kCFRunLoopDefaultMode);
-			}
+			ProcessUPSEventSource(typeRef, &newTimer, &newSource);
 		}
 		
+		CFRunLoopRef runLoop = gBackgroundRunLoop ?: CFRunLoopGetCurrent();
+		if (newSource) {
+			CFRunLoopAddSource(runLoop, newSource, kCFRunLoopDefaultMode);
+		}
+		if (newTimer) {
+			CFRunLoopAddTimer(runLoop, newTimer, kCFRunLoopDefaultMode);
+		}
 		CFRelease(typeRef);
 		typeRef = NULL;
 	}
 	
-	// Now always try to get fresh properties/capabilities/event from the plugin and replace stored copies.
-	// Use temporaries and swap under mutex to avoid races and leaks.
-	if (( result == S_OK ) && upsPlugInInterface) {
-		CFDictionaryRef newProps = NULL;
-		CFSetRef newCaps  = NULL;
-		CFDictionaryRef       newEvent = NULL;
-		
-		// attempt to get fresh values; failures are non-fatal (we keep existing ones)
+	if ((result == S_OK) && upsPlugInInterface) {
 		kr = (*upsPlugInInterface)->getProperties(upsPlugInInterface, &newProps);
-		if ((kr != kIOReturnSuccess) || (!newProps)) {
-			if (newProps) { CFRelease(newProps); newProps = NULL; }
+		if ((kr != kIOReturnSuccess) || !newProps) {
+			if (newProps) CFRelease(newProps);
+			newProps = NULL;
 		}
-		
 		kr = (*upsPlugInInterface)->getCapabilities(upsPlugInInterface, &newCaps);
-		if ((kr != kIOReturnSuccess) || (!newCaps)) {
-			if (newCaps) { CFRelease(newCaps); newCaps = NULL; }
+		if ((kr != kIOReturnSuccess) || !newCaps) {
+			if (newCaps) CFRelease(newCaps);
+			newCaps = NULL;
 		}
-		
 		kr = (*upsPlugInInterface)->getEvent(upsPlugInInterface, &newEvent);
-		if ((kr != kIOReturnSuccess) || (!newEvent)) {
-			if (newEvent) { CFRelease(newEvent); newEvent = NULL; }
+		if ((kr != kIOReturnSuccess) || !newEvent) {
+			if (newEvent) CFRelease(newEvent);
+			newEvent = NULL;
 		}
-		
-		// release the plugin interface immediately per your requirement
 		(*upsPlugInInterface)->Release(upsPlugInInterface);
 		upsPlugInInterface = NULL;
-		
-		// Atomically swap the CF objects while holding the global devices lock to avoid races
-		pthread_mutex_lock(&gAllUPSDevicesLock);
-		
+	}
+
+	if (gNotifyPort) {
+		kr = IOServiceAddInterestNotification(gNotifyPort, upsDevice, "IOGeneralInterest",
+		    DeviceNotification, upsDataRef, &newNotification);
+		if (kr == kIOReturnSuccess) {
+			UPSDataRetain(upsDataRef);
+		} else {
+			if (newNotification != MACH_PORT_NULL) IOObjectRelease(newNotification);
+			newNotification = MACH_PORT_NULL;
+		}
+	}
+
+	UPSRuntimeResources oldRuntime = {0};
+	pthread_mutex_lock(&gAllUPSDevicesLock);
+	if (!upsDataRef->removed) {
+		oldRuntime = UPSDetachRuntimeLocked(upsDataRef);
+		upsDataRef->upsEventSource = newSource;
+		upsDataRef->upsEventTimer = newTimer;
+		upsDataRef->notification = newNotification;
+		newSource = NULL;
+		newTimer = NULL;
+		newNotification = MACH_PORT_NULL;
+
 		if (newProps) {
 			if (upsDataRef->upsProperties) CFRelease(upsDataRef->upsProperties);
-			upsDataRef->upsProperties = newProps; // ownership transferred
+			upsDataRef->upsProperties = newProps;
+			newProps = NULL;
 		}
-		// else: keep existing upsProperties if fresh fetch failed
-		
 		if (newCaps) {
 			if (upsDataRef->upsCapabilities) CFRelease(upsDataRef->upsCapabilities);
 			upsDataRef->upsCapabilities = newCaps;
+			newCaps = NULL;
 		}
-		
 		if (newEvent) {
 			if (upsDataRef->upsEvent) CFRelease(upsDataRef->upsEvent);
 			upsDataRef->upsEvent = newEvent;
+			newEvent = NULL;
 		}
-		
-		pthread_mutex_unlock(&gAllUPSDevicesLock);
 	}
-	
-	// Release the original plugInInterface if still held
+	pthread_mutex_unlock(&gAllUPSDevicesLock);
+
+	UPSReleaseRuntime(oldRuntime);
+	UPSRuntimeResources unusedRuntime = {
+		.notification = newNotification,
+		.notificationOwner = newNotification != MACH_PORT_NULL ? upsDataRef : NULL,
+		.eventSource = newSource,
+		.eventTimer = newTimer,
+	};
+	UPSReleaseRuntime(unusedRuntime);
+	if (newProps) CFRelease(newProps);
+	if (newCaps) CFRelease(newCaps);
+	if (newEvent) CFRelease(newEvent);
+	if (typeRef) CFRelease(typeRef);
+	if (upsPlugInInterface) {
+		(*upsPlugInInterface)->Release(upsPlugInInterface);
+		upsPlugInInterface = NULL;
+	}
 	if (plugInInterface) {
 		(*plugInInterface)->Release(plugInInterface);
 		plugInInterface = NULL;
 	}
-	
-	// Ensure interest notification is present (best-effort)
-	if (upsDataRef->notification == MACH_PORT_NULL) {
-		kr = IOServiceAddInterestNotification(gNotifyPort, upsDevice, "IOGeneralInterest", DeviceNotification, upsDataRef, &(upsDataRef->notification));
-		if (kr != kIOReturnSuccess) {
-			upsDataRef->notification = MACH_PORT_NULL;
-		}
-	}
-}
-
-// Helper: teardown the runtime pieces of the upsDataRef but keep upsProperties/upsCapabilities/upsEvent
-static void TeardownDeviceRuntime(UPSDataRef upsDataRef) {
-	if (!upsDataRef) return;
-	
-	// Remove sources/timers on background runloop
-	if ((upsDataRef->upsEventSource || upsDataRef->upsEventTimer) && gBackgroundRunLoop) {
-		CFRetain(upsDataRef);
-		CFRunLoopPerformBlock(gBackgroundRunLoop, kCFRunLoopDefaultMode, ^{
-			if (upsDataRef->upsEventSource) {
-				CFRunLoopRemoveSource(gBackgroundRunLoop, upsDataRef->upsEventSource, kCFRunLoopDefaultMode);
-				CFRelease(upsDataRef->upsEventSource);
-				upsDataRef->upsEventSource = NULL;
-			}
-			if (upsDataRef->upsEventTimer) {
-				CFRunLoopRemoveTimer(gBackgroundRunLoop, upsDataRef->upsEventTimer, kCFRunLoopDefaultMode);
-				CFRelease(upsDataRef->upsEventTimer);
-				upsDataRef->upsEventTimer = NULL;
-			}
-			CFRelease(upsDataRef);
-		});
-		CFRunLoopWakeUp(gBackgroundRunLoop);
-	} else {
-		// best-effort immediate removal if background runloop missing
-		if (upsDataRef->upsEventSource) {
-			CFRunLoopRemoveSource(CFRunLoopGetCurrent(), upsDataRef->upsEventSource, kCFRunLoopDefaultMode);
-			CFRelease(upsDataRef->upsEventSource);
-			upsDataRef->upsEventSource = NULL;
-		}
-		if (upsDataRef->upsEventTimer) {
-			CFRunLoopRemoveTimer(CFRunLoopGetCurrent(), upsDataRef->upsEventTimer, kCFRunLoopDefaultMode);
-			CFRelease(upsDataRef->upsEventTimer);
-			upsDataRef->upsEventTimer = NULL;
-		}
-	}
-	
-	// Release plugin interface if still held
-	if (upsDataRef->upsPlugInInterface) {
-		(*upsDataRef->upsPlugInInterface)->Release(upsDataRef->upsPlugInInterface);
-		upsDataRef->upsPlugInInterface = NULL;
-	}
-	
-	// Release interest notification so we don't get callbacks while backgrounded
-	if (upsDataRef->notification != MACH_PORT_NULL) {
-		IOObjectRelease(upsDataRef->notification);
-		upsDataRef->notification = MACH_PORT_NULL;
-	}
-	
-	// Note: do NOT CFRelease upsProperties/upsCapabilities/upsEvent here — we want to keep these across backgrounding per requirement
 }
 
 // Recreate monitoring for devices that are currently present. Runs on background runloop.
 static void RecreateMonitoringForExistingDevices(void) {
-	if (!gAllUPSDevices) return;
-	
+	pthread_mutex_lock(&gAllUPSDevicesLock);
+	bool terminating = gTerminationInProgress;
+	pthread_mutex_unlock(&gAllUPSDevicesLock);
+	if (terminating) return;
+
 	// Build a matching dictionary similar to threadMain
 	CFMutableDictionaryRef matchingDict = IOServiceMatching(kIOHIDDeviceKey);
 	if (!matchingDict) {
@@ -529,20 +570,40 @@ static void RecreateMonitoringForExistingDevices(void) {
 		if (iter != MACH_PORT_NULL) IOObjectRelease(iter);
 		return;
 	}
+	CFMutableSetRef presentRegistryIDs = CFSetCreateMutable(kCFAllocatorDefault,
+	    0, &kCFTypeSetCallBacks);
+	bool canReconcile = presentRegistryIDs != NULL;
 	
 	// Iterate present devices; for each, try to match by registry entry ID to an existing element in gAllUPSDevices
 	io_service_t service;
 	while ((service = IOIteratorNext(iter))) {
 		uint64_t entryID = 0;
-		IORegistryEntryGetRegistryEntryID(service, &entryID);
+		kr = IORegistryEntryGetRegistryEntryID(service, &entryID);
+		if (kr != kIOReturnSuccess) {
+			canReconcile = false;
+			IOObjectRelease(service);
+			continue;
+		}
+		if (canReconcile) {
+			CFNumberRef registryID = CFNumberCreate(kCFAllocatorDefault,
+			    kCFNumberSInt64Type, &entryID);
+			if (registryID) {
+				CFSetAddValue(presentRegistryIDs, registryID);
+				CFRelease(registryID);
+			} else {
+				canReconcile = false;
+			}
+		}
 		
 		// find an upsDataRef with same regID
 		pthread_mutex_lock(&gAllUPSDevicesLock);
 		UPSDataRef matched = NULL;
-		for (size_t i = 0; i < gAllUPSDevices->count; i++) {
-			if (gAllUPSDevices->items[i]->regID == entryID) {
-				matched = gAllUPSDevices->items[i];
-				break;
+		if (gAllUPSDevices) {
+			for (size_t i = 0; i < gAllUPSDevices->count; i++) {
+				if (gAllUPSDevices->items[i]->regID == entryID) {
+					matched = UPSDataRetain(gAllUPSDevices->items[i]);
+					break;
+				}
 			}
 		}
 		pthread_mutex_unlock(&gAllUPSDevicesLock);
@@ -550,6 +611,7 @@ static void RecreateMonitoringForExistingDevices(void) {
 		if (matched) {
 			// set up plugin and event source for the existing upsDataRef
 			SetupPluginAndEventSourceForDevice(matched, service);
+			UPSDataRelease(matched);
 		} else {
 			// no existing device with that regID — normal: let UPSDeviceAdded handle it (it will be called via first-match notifications)
 		}
@@ -557,6 +619,8 @@ static void RecreateMonitoringForExistingDevices(void) {
 		IOObjectRelease(service);
 	}
 	IOObjectRelease(iter);
+	if (canReconcile) AllUPSDevicesRemoveMissing(presentRegistryIDs);
+	if (presentRegistryIDs) CFRelease(presentRegistryIDs);
 }
 
 // Called by the IOKit matching notification when devices are added
@@ -582,6 +646,7 @@ UPSDeviceAdded(void *refCon, io_iterator_t iterator)
 		
 		uint64_t entryID = 0;
 		IORegistryEntryGetRegistryEntryID(upsDevice, &entryID);
+		upsDataRef->retainCount        = 1;
 		upsDataRef->regID              = entryID;
 		upsDataRef->notification       = MACH_PORT_NULL;
 		upsDataRef->upsPlugInInterface = NULL;
@@ -592,9 +657,9 @@ UPSDeviceAdded(void *refCon, io_iterator_t iterator)
 		upsDataRef->upsEventTimer      = NULL;
 		
 		// If we already have a device with this registry ID, avoid creating a duplicate. Free the temp and continue.
-		if (gAllUPSDevices && UPSDeviceSetContainsByID(gAllUPSDevices, entryID)) {
+		if (AllUPSDevicesContainsByID(entryID)) {
 			DBGLOG(@"[UPSMonitor] device with regID %llu already present - skipping", entryID);
-			free(upsDataRef);
+			UPSDataRelease(upsDataRef);
 			IOObjectRelease(upsDevice);
 			continue;
 		}
@@ -672,34 +737,23 @@ UPSDeviceAdded(void *refCon, io_iterator_t iterator)
 			
 			// Create interest notification and add to set
 			kr = IOServiceAddInterestNotification(gNotifyPort, upsDevice, "IOGeneralInterest", DeviceNotification, upsDataRef, &(upsDataRef->notification));
-			if (kr != kIOReturnSuccess) {
+			if (kr == kIOReturnSuccess) {
+				UPSDataRetain(upsDataRef);
+			} else {
+				if (upsDataRef->notification != MACH_PORT_NULL) {
+					IOObjectRelease(upsDataRef->notification);
+				}
 				upsDataRef->notification = MACH_PORT_NULL;
 			}
 			
-			if (!gAllUPSDevices) {
-				gAllUPSDevices = UPSDeviceSetCreate();
+			if (plugInInterface) {
+				(*plugInInterface)->Release(plugInInterface);
+				plugInInterface = NULL;
 			}
-			if (!UPSDeviceSetAdd(gAllUPSDevices, upsDataRef)) {
+			if (!AllUPSDevicesAdd(upsDataRef)) {
 				// If we failed to add (race or duplicate), cleanup upsDataRef to avoid leak
 				DBGLOG(@"[UPSMonitor] Failed to add upsDataRef to global set - cleaning up");
-				if (upsDataRef->notification != MACH_PORT_NULL) {
-					IOObjectRelease(upsDataRef->notification);
-					upsDataRef->notification = MACH_PORT_NULL;
-				}
-				if (upsDataRef->upsEventSource) {
-					CFRunLoopRemoveSource(CFRunLoopGetCurrent(), upsDataRef->upsEventSource, kCFRunLoopDefaultMode);
-					CFRelease(upsDataRef->upsEventSource);
-					upsDataRef->upsEventSource = NULL;
-				}
-				if (upsDataRef->upsEventTimer) {
-					CFRunLoopRemoveTimer(CFRunLoopGetCurrent(), upsDataRef->upsEventTimer, kCFRunLoopDefaultMode);
-					CFRelease(upsDataRef->upsEventTimer);
-					upsDataRef->upsEventTimer = NULL;
-				}
-				if (upsDataRef->upsProperties) CFRelease(upsDataRef->upsProperties);
-				if (upsDataRef->upsCapabilities) CFRelease(upsDataRef->upsCapabilities);
-				if (upsDataRef->upsEvent) CFRelease(upsDataRef->upsEvent);
-				free(upsDataRef);
+				FreeUPSData(upsDataRef);
 				upsDataRef = NULL;
 				IOObjectRelease(upsDevice);
 				continue;
@@ -713,33 +767,18 @@ UPSDeviceAdded(void *refCon, io_iterator_t iterator)
 		}
 		
 	CLEANUP_PARTIAL:
-		// (same cleanup logic as before), but be careful to only release what we have.
 		if (upsDataRef) {
 			DBGLOG(@"[UPSMonitor] cleanup");
-			if (upsDataRef->notification != MACH_PORT_NULL) {
-				IOObjectRelease(upsDataRef->notification);
-				upsDataRef->notification = MACH_PORT_NULL;
-			}
-			// if plugin interface stored, release it
-			if (upsDataRef->upsPlugInInterface) {
-				(*upsDataRef->upsPlugInInterface)->Release(upsDataRef->upsPlugInInterface);
-				upsDataRef->upsPlugInInterface = NULL;
-			}
-			if (upsDataRef->upsProperties)     CFRelease(upsDataRef->upsProperties);
-			if (upsDataRef->upsCapabilities)   CFRelease(upsDataRef->upsCapabilities);
-			if (upsDataRef->upsEvent)          CFRelease(upsDataRef->upsEvent);
-			if (upsDataRef->upsEventSource) {
-				CFRunLoopRemoveSource(CFRunLoopGetCurrent(), upsDataRef->upsEventSource, kCFRunLoopDefaultMode);
-				CFRelease(upsDataRef->upsEventSource);
-				upsDataRef->upsEventSource = NULL;
-			}
-			if (upsDataRef->upsEventTimer) {
-				CFRunLoopRemoveTimer(CFRunLoopGetCurrent(), upsDataRef->upsEventTimer, kCFRunLoopDefaultMode);
-				CFRelease(upsDataRef->upsEventTimer);
-				upsDataRef->upsEventTimer = NULL;
-			}
-			free(upsDataRef);
+			FreeUPSData(upsDataRef);
 			upsDataRef = NULL;
+		}
+		if (typeRef) {
+			CFRelease(typeRef);
+			typeRef = NULL;
+		}
+		if (upsPlugInInterface) {
+			(*upsPlugInInterface)->Release(upsPlugInInterface);
+			upsPlugInInterface = NULL;
 		}
 		if (plugInInterface) {
 			(*plugInInterface)->Release(plugInInterface);
@@ -749,21 +788,43 @@ UPSDeviceAdded(void *refCon, io_iterator_t iterator)
 	}
 }
 
-// --- threadMain and signal handling largely unchanged, small guard added ---
-static void
-threadMain(void)
+static void UPSKeepAlivePerform(void *info) {}
+
+static void *
+threadMain(void *context)
 {
 	@autoreleasepool {
-		gNotifyPort = IONotificationPortCreate(kIOMasterPortDefault);
-		if (!gNotifyPort) {
+		IONotificationPortRef notifyPort = IONotificationPortCreate(kIOMasterPortDefault);
+		CFRunLoopSourceRef keepAliveSource = NULL;
+		CFRunLoopRef runLoopToRelease = NULL;
+		if (!notifyPort) {
 			NSLog(@"[UPSMonitor] ERROR: failed to create IONotificationPort");
-			return;
+			goto CLEANUP_ALL;
 		}
 		
-		CFRunLoopSourceRef rlSrc = IONotificationPortGetRunLoopSource(gNotifyPort);
-		CFRunLoopAddSource(CFRunLoopGetCurrent(), rlSrc, kCFRunLoopDefaultMode);
-		gBackgroundRunLoop = CFRunLoopGetCurrent();
-		CFRetain(gBackgroundRunLoop);
+		CFRunLoopRef currentRunLoop = CFRunLoopGetCurrent();
+		CFRunLoopSourceRef notificationSource = IONotificationPortGetRunLoopSource(notifyPort);
+		CFRunLoopSourceContext keepAliveContext = {
+			.version = 0,
+			.perform = UPSKeepAlivePerform,
+		};
+		keepAliveSource = CFRunLoopSourceCreate(kCFAllocatorDefault, 0, &keepAliveContext);
+		if (!notificationSource || !keepAliveSource) {
+			NSLog(@"[UPSMonitor] ERROR: failed to create run loop sources");
+			goto CLEANUP_ALL;
+		}
+		CFRunLoopAddSource(currentRunLoop, notificationSource, kCFRunLoopDefaultMode);
+		CFRunLoopAddSource(currentRunLoop, keepAliveSource, kCFRunLoopDefaultMode);
+
+		pthread_mutex_lock(&gAllUPSDevicesLock);
+		bool shouldTerminate = gTerminationInProgress;
+		if (!shouldTerminate) {
+			gNotifyPort = notifyPort;
+			gBackgroundRunLoop = currentRunLoop;
+			CFRetain(gBackgroundRunLoop);
+		}
+		pthread_mutex_unlock(&gAllUPSDevicesLock);
+		if (shouldTerminate) goto CLEANUP_ALL;
 		
 		CFMutableDictionaryRef matchingDict = IOServiceMatching(kIOHIDDeviceKey);
 		if (!matchingDict) {
@@ -830,7 +891,7 @@ threadMain(void)
 		devicePairs = NULL;
 		
 		// Now set up the “first match” notification so UPSDeviceAdded() is called whenever a device arrives.
-		kern_return_t kr = IOServiceAddMatchingNotification(gNotifyPort, kIOFirstMatchNotification, matchingDict, UPSDeviceAdded, NULL, &gAddedIter);
+		kern_return_t kr = IOServiceAddMatchingNotification(notifyPort, kIOFirstMatchNotification, matchingDict, UPSDeviceAdded, NULL, &gAddedIter);
 		// matchingDict is retained by IOKit (no need to CFRelease here; IOKit takes ownership)
 		matchingDict = NULL;
 		
@@ -841,45 +902,49 @@ threadMain(void)
 		DBGLOG(@"[UPSMonitor] thread setup");
 		// Drain any already‐present devices so they don’t get missed
 		UPSDeviceAdded(NULL, gAddedIter);
-		
+		pthread_mutex_lock(&gAllUPSDevicesLock);
+		gWatchThreadReady = true;
+		pthread_cond_broadcast(&gWatchStateCondition);
+		pthread_mutex_unlock(&gAllUPSDevicesLock);
+
 		CFRunLoopRun();
 		
 	CLEANUP_ALL:
-		if (gBackgroundRunLoop) {
-			CFRelease(gBackgroundRunLoop);
-			gBackgroundRunLoop = NULL;
-		}
-		
+		pthread_mutex_lock(&gAllUPSDevicesLock);
+		if (gNotifyPort == notifyPort) gNotifyPort = NULL;
+		runLoopToRelease = gBackgroundRunLoop;
+		gBackgroundRunLoop = NULL;
+		gWatchThreadReady = false;
+		UPSWatching = false;
+		gWatchThreadExited = true;
+		gNotificationsPaused = false;
+		pthread_cond_broadcast(&gWatchStateCondition);
+		pthread_mutex_unlock(&gAllUPSDevicesLock);
+
 		if (gAddedIter != MACH_PORT_NULL) {
 			IOObjectRelease(gAddedIter);
 			gAddedIter = MACH_PORT_NULL;
 		}
 		
-		if (gAllUPSDevices) {
-			size_t n = UPSDeviceSetCount(gAllUPSDevices);
-			UPSDataRef *buffer = calloc(n, sizeof(UPSDataRef));
-			UPSDeviceSetGetAll(gAllUPSDevices, buffer);
-			for (size_t i = 0; i < n; i++) {
-				FreeUPSData(buffer[i]);
-			}
-			free(buffer);
-			UPSDeviceSetDestroy(gAllUPSDevices);
-			gAllUPSDevices = NULL;
+		UPSDeviceSet *set = AllUPSDevicesTake();
+		if (set) {
+			for (size_t i = 0; i < set->count; i++) FreeUPSData(set->items[i]);
+			UPSDeviceSetDestroy(set);
 		}
 		
-		
-		if (gNotifyPort) {
-			IONotificationPortDestroy(gNotifyPort);
-			gNotifyPort = NULL;
+		if (keepAliveSource) {
+			CFRunLoopSourceInvalidate(keepAliveSource);
+			CFRelease(keepAliveSource);
 		}
+		if (notifyPort) IONotificationPortDestroy(notifyPort);
+		if (runLoopToRelease) CFRelease(runLoopToRelease);
 	}
+	return NULL;
 }
 
-// Signal and cleanup functions unchanged except ensure cleanupAllResources uses TeardownDeviceRuntime
 void SignalHandler(int sigraised) {
-	syslog(LOG_INFO, "Battman: received signal %d, exiting gracefully\n", sigraised);
-	[UPSMonitor cleanupAllResources];
-	// app_exit();
+	// Process teardown is not async-signal-safe; the OS reclaims these resources.
+	_exit(128 + sigraised);
 }
 
 // Update the CleanupAndExit function
@@ -888,79 +953,57 @@ void CleanupAndExit(void) {
 	CFRunLoopStop(CFRunLoopGetCurrent());
 }
 
-static bool gNotificationsPaused = false;
++ (void)_cleanupAllResourcesLocked
+{
+	pthread_mutex_lock(&gAllUPSDevicesLock);
+	if (gTerminationInProgress) {
+		pthread_mutex_unlock(&gAllUPSDevicesLock);
+		return;
+	}
+	gTerminationInProgress = true;
+	gNotificationsPaused = false;
+	CFRunLoopRef runLoop = gBackgroundRunLoop;
+	if (runLoop) CFRetain(runLoop);
+	pthread_t watchThread = gUPSWatchThread;
+	pthread_mutex_unlock(&gAllUPSDevicesLock);
+	
+	NSLog(@"[UPSMonitor] Starting graceful shutdown...");
+	cleanupPowerEventMonitoring();
+
+	if (runLoop) {
+		CFRunLoopPerformBlock(runLoop, kCFRunLoopDefaultMode, ^{
+			CFRunLoopStop(CFRunLoopGetCurrent());
+		});
+		CFRunLoopWakeUp(runLoop);
+		CFRelease(runLoop);
+	}
+	if (watchThread && !pthread_equal(watchThread, pthread_self())) {
+		pthread_join(watchThread, NULL);
+		pthread_mutex_lock(&gAllUPSDevicesLock);
+		if (pthread_equal(gUPSWatchThread, watchThread)) gUPSWatchThread = 0;
+		UPSWatching = false;
+		gWatchThreadExited = false;
+		pthread_mutex_unlock(&gAllUPSDevicesLock);
+	} else if (!watchThread) {
+		UPSDeviceSet *set = AllUPSDevicesTake();
+		if (set) {
+			for (size_t i = 0; i < set->count; i++) FreeUPSData(set->items[i]);
+			UPSDeviceSetDestroy(set);
+		}
+		pthread_mutex_lock(&gAllUPSDevicesLock);
+		UPSWatching = false;
+		gWatchThreadExited = false;
+		pthread_mutex_unlock(&gAllUPSDevicesLock);
+	}
+
+	NSLog(@"[UPSMonitor] Graceful shutdown completed");
+}
 
 + (void)cleanupAllResources
 {
-	if (gTerminationInProgress) {
-		return; // Prevent double cleanup
-	}
-	gTerminationInProgress = true;
-	
-	NSLog(@"[UPSMonitor] Starting graceful shutdown...");
-	
-	// Stop power event monitoring first
-	cleanupPowerEventMonitoring();
-	
-	// Stop the UPS monitoring run loop if it's running
-	if (gBackgroundRunLoop) {
-		CFRunLoopPerformBlock(gBackgroundRunLoop, kCFRunLoopDefaultMode, ^{
-			CFRunLoopStop(CFRunLoopGetCurrent());
-		});
-		CFRunLoopWakeUp(gBackgroundRunLoop);
-		
-		// Give the run loop time to stop gracefully
-		dispatch_semaphore_t stopSemaphore = dispatch_semaphore_create(0);
-		dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-			// Wait a bit for the run loop to stop
-			usleep(100000); // 100ms
-			dispatch_semaphore_signal(stopSemaphore);
-		});
-		
-		// Wait up to 1 second for graceful shutdown
-		dispatch_semaphore_wait(stopSemaphore, dispatch_time(DISPATCH_TIME_NOW, 1 * NSEC_PER_SEC));
-	}
-	
-	// Clean up all UPS devices
-	if (gAllUPSDevices) {
-		NSLog(@"[UPSMonitor] Cleaning up %zu UPS devices", UPSDeviceSetCount(gAllUPSDevices));
-		size_t n = UPSDeviceSetCount(gAllUPSDevices);
-		if (n > 0) {
-			UPSDataRef *buffer = calloc(n, sizeof(UPSDataRef));
-			if (buffer) {
-				UPSDeviceSetGetAll(gAllUPSDevices, buffer);
-				for (size_t i = 0; i < n; i++) {
-					FreeUPSData(buffer[i]);
-				}
-				free(buffer);
-			}
-		}
-		UPSDeviceSetDestroy(gAllUPSDevices);
-		gAllUPSDevices = NULL;
-	}
-	
-	// Clean up IOKit resources
-	if (gAddedIter != MACH_PORT_NULL) {
-		IOObjectRelease(gAddedIter);
-		gAddedIter = MACH_PORT_NULL;
-	}
-	
-	if (gNotifyPort) {
-		IONotificationPortDestroy(gNotifyPort);
-		gNotifyPort = NULL;
-	}
-	
-	// Clean up run loop reference
-	if (gBackgroundRunLoop) {
-		CFRelease(gBackgroundRunLoop);
-		gBackgroundRunLoop = NULL;
-	}
-	
-	// Reset state
-	UPSWatching = false;
-	gNotificationsPaused = false;
-	
-	NSLog(@"[UPSMonitor] Graceful shutdown completed");
+	pthread_mutex_lock(&gWatchLifecycleLock);
+	[self _cleanupAllResourcesLocked];
+	pthread_mutex_unlock(&gWatchLifecycleLock);
 }
 
 // app background/foreground handling — updated to teardown/recreate runtime parts (but keep CF properties)
@@ -972,124 +1015,192 @@ static bool gNotificationsPaused = false;
 
 + (void)appDidEnterBackground:(NSNotification *)note
 {
-	if (gTerminationInProgress) return;
-	
-	extern dispatch_queue_t _powerQueue;
-	
-	// stop power monitoring first
-	suspendPowerEventMonitoring();
-	
-	// If already paused or not initialized, nothing to do
-	if (gBackgroundRunLoop == NULL || gNotifyPort == NULL || gNotificationsPaused)
+	pthread_mutex_lock(&gWatchLifecycleLock);
+	pthread_mutex_lock(&gAllUPSDevicesLock);
+	bool terminating = gTerminationInProgress;
+	pthread_mutex_unlock(&gAllUPSDevicesLock);
+	if (terminating) {
+		pthread_mutex_unlock(&gWatchLifecycleLock);
 		return;
-	
-	CFRunLoopSourceRef src = IONotificationPortGetRunLoopSource(gNotifyPort);
-	if (!src) return;
-	
-	// Remove the UPS monitoring run loop source
-	CFRunLoopPerformBlock(gBackgroundRunLoop, kCFRunLoopDefaultMode, ^{
-		CFRunLoopRemoveSource(CFRunLoopGetCurrent(), src, kCFRunLoopDefaultMode);
-	});
-	CFRunLoopWakeUp(gBackgroundRunLoop);
-	
-	// Teardown runtime pieces of each device (leave properties/capabilities/events)
-	if (gAllUPSDevices) {
-		size_t n = UPSDeviceSetCount(gAllUPSDevices);
-		if (n > 0) {
-			UPSDataRef *buffer = calloc(n, sizeof(UPSDataRef));
-			if (buffer) {
-				UPSDeviceSetGetAll(gAllUPSDevices, buffer);
-				for (size_t i = 0; i < n; i++) {
-					TeardownDeviceRuntime(buffer[i]);
-				}
-				free(buffer);
-			}
+	}
+
+	suspendPowerEventMonitoring();
+
+	CFRunLoopRef runLoop = NULL;
+	CFRunLoopSourceRef notificationSource = NULL;
+	pthread_mutex_lock(&gAllUPSDevicesLock);
+	if (!gTerminationInProgress && !gNotificationsPaused &&
+	    gBackgroundRunLoop && gNotifyPort) {
+		notificationSource = IONotificationPortGetRunLoopSource(gNotifyPort);
+		if (notificationSource) {
+			CFRetain(notificationSource);
+			runLoop = gBackgroundRunLoop;
+			CFRetain(runLoop);
+			gNotificationsPaused = true;
 		}
 	}
-	
-	gNotificationsPaused = true;
+	pthread_mutex_unlock(&gAllUPSDevicesLock);
+	if (!runLoop || !notificationSource) {
+		pthread_mutex_unlock(&gWatchLifecycleLock);
+		return;
+	}
+
+	CFRunLoopRemoveSource(runLoop, notificationSource, kCFRunLoopDefaultMode);
+	CFRelease(notificationSource);
+	CFRunLoopPerformBlock(runLoop, kCFRunLoopDefaultMode, ^{
+		size_t count = 0;
+		UPSDataRef *devices = AllUPSDevicesCopy(&count);
+		for (size_t i = 0; i < count; i++) {
+			TeardownDeviceRuntime(devices[i]);
+			UPSDataRelease(devices[i]);
+		}
+		free(devices);
+	});
+	CFRunLoopWakeUp(runLoop);
+	CFRelease(runLoop);
+
 	NSLog(@"[UPSMonitor] Suspended monitoring - app entered background (plugin/interfaces released, CF props retained)");
+	pthread_mutex_unlock(&gWatchLifecycleLock);
 }
 
 + (void)appWillEnterForeground:(NSNotification *)note
 {
-	if (gTerminationInProgress) return;
-	
-	extern dispatch_queue_t _powerQueue;
-	
-	// resume power monitoring first
-	resumePowerEventMonitoring();
-	
-	if (gBackgroundRunLoop == NULL || gNotifyPort == NULL || !gNotificationsPaused)
+	pthread_mutex_lock(&gWatchLifecycleLock);
+	pthread_mutex_lock(&gAllUPSDevicesLock);
+	bool terminating = gTerminationInProgress;
+	pthread_mutex_unlock(&gAllUPSDevicesLock);
+	if (terminating) {
+		pthread_mutex_unlock(&gWatchLifecycleLock);
 		return;
-	
-	CFRunLoopSourceRef src = IONotificationPortGetRunLoopSource(gNotifyPort);
-	if (!src) return;
-	
-	// Add back the UPS monitoring run loop source
-	CFRunLoopPerformBlock(gBackgroundRunLoop, kCFRunLoopDefaultMode, ^{
-		CFRunLoopAddSource(CFRunLoopGetCurrent(), src, kCFRunLoopDefaultMode);
-	});
-	CFRunLoopWakeUp(gBackgroundRunLoop);
-	
-	// Recreate plugin/interfaces/event sources for existing devices on the background runloop
-	if (gAllUPSDevices) {
-		CFRunLoopPerformBlock(gBackgroundRunLoop, kCFRunLoopDefaultMode, ^{
-			RecreateMonitoringForExistingDevices();
-		});
-		CFRunLoopWakeUp(gBackgroundRunLoop);
 	}
-	
-	gNotificationsPaused = false;
+
+	resumePowerEventMonitoring();
+
+	CFRunLoopRef runLoop = NULL;
+	CFRunLoopSourceRef notificationSource = NULL;
+	pthread_mutex_lock(&gAllUPSDevicesLock);
+	if (!gTerminationInProgress && gNotificationsPaused &&
+	    gBackgroundRunLoop && gNotifyPort) {
+		notificationSource = IONotificationPortGetRunLoopSource(gNotifyPort);
+		if (notificationSource) {
+			CFRetain(notificationSource);
+			runLoop = gBackgroundRunLoop;
+			CFRetain(runLoop);
+			gNotificationsPaused = false;
+		}
+	}
+	pthread_mutex_unlock(&gAllUPSDevicesLock);
+	if (!runLoop || !notificationSource) {
+		pthread_mutex_unlock(&gWatchLifecycleLock);
+		return;
+	}
+
+	CFRunLoopAddSource(runLoop, notificationSource, kCFRunLoopDefaultMode);
+	CFRelease(notificationSource);
+	CFRunLoopPerformBlock(runLoop, kCFRunLoopDefaultMode, ^{
+		RecreateMonitoringForExistingDevices();
+	});
+	CFRunLoopWakeUp(runLoop);
+	CFRelease(runLoop);
+
 	NSLog(@"[UPSMonitor] Resumed monitoring - app will enter foreground");
+	pthread_mutex_unlock(&gWatchLifecycleLock);
 }
 
 
 + (void)startWatchingUPS
 {
 	DBGLOG(@"[UPSMonitor] called");
-	if (UPSWatching) {
+	pthread_mutex_lock(&gWatchLifecycleLock);
+	pthread_t exitedThread = 0;
+	pthread_mutex_lock(&gAllUPSDevicesLock);
+	if (gUPSWatchThread && gWatchThreadExited && !UPSWatching) {
+		exitedThread = gUPSWatchThread;
+		gUPSWatchThread = 0;
+		gWatchThreadExited = false;
+	} else if (UPSWatching || gUPSWatchThread || gWatchThreadStarting) {
+		pthread_mutex_unlock(&gAllUPSDevicesLock);
+		pthread_mutex_unlock(&gWatchLifecycleLock);
 		return;
 	}
+	gWatchThreadStarting = true;
+	gWatchThreadReady = false;
+	gTerminationInProgress = false;
+	gNotificationsPaused = false;
+	pthread_mutex_unlock(&gAllUPSDevicesLock);
+	if (exitedThread) pthread_join(exitedThread, NULL);
 	
-	NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
-	[nc addObserver:self selector:@selector(appDidEnterBackground:) name:UIApplicationDidEnterBackgroundNotification object:nil];
-	[nc addObserver:self selector:@selector(appWillEnterForeground:) name:UIApplicationWillEnterForegroundNotification object:nil];
-	[nc addObserver:self selector:@selector(appWillTerminate:) name:UIApplicationWillTerminateNotification object:nil];
-	
-	// Install a signal handler so if someone ^C’s, we clean up
-	signal(SIGINT, SignalHandler);
-	signal(SIGTERM, SignalHandler);
-	
-	// Spawn a detached pthread that we do not affect the UIKit
-	pthread_t thread;
+	// Keep the watch thread joinable so cleanup can synchronize ownership.
+	pthread_t thread = 0;
 	pthread_attr_t attrs;
 	pthread_attr_init(&attrs);
-	pthread_attr_setdetachstate(&attrs, PTHREAD_CREATE_DETACHED);
 	
-	int err = pthread_create(&thread, &attrs, (void *(*)(void *))threadMain, NULL);
+	pthread_mutex_lock(&gAllUPSDevicesLock);
+	bool cancelled = gTerminationInProgress;
+	int err = cancelled ? 0 : pthread_create(&thread, &attrs, threadMain, NULL);
+	if (!cancelled && !err) {
+		gUPSWatchThread = thread;
+		UPSWatching = true;
+		gWatchThreadExited = false;
+		NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
+		[nc removeObserver:self name:UIApplicationDidEnterBackgroundNotification object:nil];
+		[nc removeObserver:self name:UIApplicationWillEnterForegroundNotification object:nil];
+		[nc removeObserver:self name:UIApplicationWillTerminateNotification object:nil];
+		[nc addObserver:self selector:@selector(appDidEnterBackground:) name:UIApplicationDidEnterBackgroundNotification object:nil];
+		[nc addObserver:self selector:@selector(appWillEnterForeground:) name:UIApplicationWillEnterForegroundNotification object:nil];
+		[nc addObserver:self selector:@selector(appWillTerminate:) name:UIApplicationWillTerminateNotification object:nil];
+		signal(SIGINT, SignalHandler);
+		signal(SIGTERM, SignalHandler);
+	}
+	gWatchThreadStarting = false;
+	pthread_mutex_unlock(&gAllUPSDevicesLock);
 	pthread_attr_destroy(&attrs);
+	if (cancelled) {
+		pthread_mutex_unlock(&gWatchLifecycleLock);
+		return;
+	}
 	
 	if (err) {
 		NSLog(@"[UPSMonitor] Failed to create UPS‐watch thread: %d", err);
 	} else {
-		gUPSWatchThread = thread;
-		NSLog(@"[UPSMonitor] UPS‐watch thread launched.");
-		UPSWatching = true;
+		pthread_mutex_lock(&gAllUPSDevicesLock);
+		while (!gWatchThreadReady && !gWatchThreadExited) {
+			pthread_cond_wait(&gWatchStateCondition, &gAllUPSDevicesLock);
+		}
+		bool ready = gWatchThreadReady;
+		pthread_mutex_unlock(&gAllUPSDevicesLock);
+		if (ready) {
+			NSLog(@"[UPSMonitor] UPS‐watch thread launched.");
+		} else {
+			pthread_join(thread, NULL);
+			pthread_mutex_lock(&gAllUPSDevicesLock);
+			if (pthread_equal(gUPSWatchThread, thread)) gUPSWatchThread = 0;
+			UPSWatching = false;
+			gWatchThreadExited = false;
+			pthread_mutex_unlock(&gAllUPSDevicesLock);
+			NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
+			[nc removeObserver:self name:UIApplicationDidEnterBackgroundNotification object:nil];
+			[nc removeObserver:self name:UIApplicationWillEnterForegroundNotification object:nil];
+			[nc removeObserver:self name:UIApplicationWillTerminateNotification object:nil];
+			NSLog(@"[UPSMonitor] UPS‐watch thread failed during initialization.");
+		}
 	}
+	pthread_mutex_unlock(&gWatchLifecycleLock);
 }
 
 // manually stop monitoring (useful for testing ig)
 + (void)stopWatchingUPS
 {
 	NSLog(@"[UPSMonitor] Manually stopping UPS monitoring");
-	[self cleanupAllResources];
+	pthread_mutex_lock(&gWatchLifecycleLock);
+	[self _cleanupAllResourcesLocked];
 	
 	// Remove notification observers
 	NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
 	[nc removeObserver:self name:UIApplicationDidEnterBackgroundNotification object:nil];
 	[nc removeObserver:self name:UIApplicationWillEnterForegroundNotification object:nil];
 	[nc removeObserver:self name:UIApplicationWillTerminateNotification object:nil];
+	pthread_mutex_unlock(&gWatchLifecycleLock);
 }
 
 @end

--- a/Battman/UPSMonitor.h
+++ b/Battman/UPSMonitor.h
@@ -103,6 +103,8 @@ __BEGIN_DECLS
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnullability-completeness"
 typedef struct UPSData {
+	uint32_t                    retainCount;          // internal lifetime management
+	bool                        removed;              // no new runtime state after detach
 	uint64_t                    regID;
 	io_object_t                 notification;          // returned by IOServiceAddInterestNotification
 	IOUPSPlugInInterface **     upsPlugInInterface;    // the v140 or old plugin Interface
@@ -138,10 +140,15 @@ typedef struct ups_batt {
 	int time_to_full;
 } ups_batt_t;
 
+typedef struct ups_battery_snapshot {
+	ups_batt_t battery;
+	int cell_count;
+} UPSBatterySnapshot;
+
 extern UPSDeviceSet *gAllUPSDevices;
 
 void PrintAllUPSDevices(void);
-UPSDataRef UPSDeviceMatchingVendorProduct(int vid, int pid);
+bool UPSCopyBatterySnapshot(int vid, int pid, UPSBatterySnapshot *snapshot);
 ups_batt_t ups_battery_info(UPSDataRef device);
 
 #pragma clang diagnostic pop

--- a/Battman/UPSMonitor.m
+++ b/Battman/UPSMonitor.m
@@ -609,37 +609,42 @@ static bool gNotificationsPaused = false;
 
 @end
 
-UPSDataRef UPSDeviceMatchingVendorProduct(int vid, int pid) {
-	UPSDataRef ret = NULL;
-	if (!gAllUPSDevices || gAllUPSDevices->count == 0) {
-		DBGLOG(@"[UPSMonitor] no UPS devices yet");
-		return NULL;
-	}
-	if (vid == 0 || pid == 0) {
-		return NULL;
-	}
-	
+bool UPSCopyBatterySnapshot(int vid, int pid, UPSBatterySnapshot *snapshot) {
+	if (!snapshot) return false;
+	memset(snapshot, 0, sizeof(*snapshot));
+	if (!gAllUPSDevices || vid == 0 || pid == 0) return false;
+
 	for (size_t i = 0; i < gAllUPSDevices->count; i++) {
-		UPSDataRef d = gAllUPSDevices->items[i];
-		
-		SInt32 vendor, product;
-		CFNumberRef number;
-		if (d->upsProperties) {
-			number = CFDictionaryGetValue(d->upsProperties, CFSTR("Vendor ID"));
-			if (!number || !CFNumberGetValue(number, kCFNumberSInt32Type, &vendor)) {
-				continue;
-			}
-			number = CFDictionaryGetValue(d->upsProperties, CFSTR("Product ID"));
-			if (!number || !CFNumberGetValue(number, kCFNumberSInt32Type, &product)) {
-				continue;
-			}
-			if ((vendor == vid) && (product == pid)) {
-				ret = d;
-				break;
+		UPSDataRef device = gAllUPSDevices->items[i];
+		if (!device->upsProperties ||
+		    CFGetTypeID(device->upsProperties) != CFDictionaryGetTypeID()) continue;
+		SInt32 vendor = 0;
+		SInt32 product = 0;
+		CFNumberRef number = CFDictionaryGetValue(device->upsProperties, CFSTR("Vendor ID"));
+		if (!number || CFGetTypeID(number) != CFNumberGetTypeID() ||
+		    !CFNumberGetValue(number, kCFNumberSInt32Type, &vendor)) continue;
+		number = CFDictionaryGetValue(device->upsProperties, CFSTR("Product ID"));
+		if (!number || CFGetTypeID(number) != CFNumberGetTypeID() ||
+		    !CFNumberGetValue(number, kCFNumberSInt32Type, &product)) continue;
+		if (vendor != vid || product != pid) continue;
+
+		snapshot->battery = ups_battery_info(device);
+		if (device->upsCapabilities &&
+		    CFGetTypeID(device->upsCapabilities) == CFSetGetTypeID()) {
+			CFIndex count = CFSetGetCount(device->upsCapabilities);
+			for (CFIndex cell = 0; cell < count; cell++) {
+				CFStringRef key = CFStringCreateWithFormat(kCFAllocatorDefault, NULL,
+				    CFSTR("Cell %ld Voltage"), cell);
+				if (!key) break;
+				bool present = CFSetContainsValue(device->upsCapabilities, key);
+				CFRelease(key);
+				if (!present) break;
+				snapshot->cell_count++;
 			}
 		}
+		return true;
 	}
-	return ret;
+	return false;
 }
 
 #endif
@@ -666,15 +671,20 @@ void PrintAllUPSDevices(void) {
 }
 #endif
 
-#define GetIntForKey(x, y, z) 										\
-	number = CFDictionaryGetValue(x, CFSTR(y));							\
-	if (!number || !CFNumberGetValue(number, kCFNumberIntType, &(z)))	\
-		z = 0
+#define GetIntForKey(x, y, z) do { \
+	(z) = 0; \
+	if ((x) && CFGetTypeID(x) == CFDictionaryGetTypeID()) { \
+		number = CFDictionaryGetValue((x), CFSTR(y)); \
+		if (!number || CFGetTypeID(number) != CFNumberGetTypeID() || \
+		    !CFNumberGetValue(number, kCFNumberIntType, &(z))) (z) = 0; \
+	} \
+} while (0)
 
 ups_batt_t ups_battery_info(UPSDataRef device) {
 	ups_batt_t info = {0};
 
-	if (!device || !device->upsEvent) return info;
+	if (!device || !device->upsEvent ||
+	    CFGetTypeID(device->upsEvent) != CFDictionaryGetTypeID()) return info;
 
 	CFNumberRef number;
 	/* Do not show Nominal Capacity, to avoid confusions */

--- a/Battman/battery_utils/accessory.c
+++ b/Battman/battery_utils/accessory.c
@@ -116,7 +116,7 @@ extern const char *cond_localize_c(const char *);
 
 void acc_powermode_string(AccessoryPowermode powermode, char **pbuf) {
 	// IOAM modes are starting form 1
-	if ((powermode - 1) < kIOAMPowermodeCount) {
+	if (powermode >= kIOAMPowermodeOff && powermode <= kIOAMPowermodeCount) {
 		*pbuf=stpcpy(*pbuf,_C(acc_powermodes[powermode - 1]));
 		return;
 	}
@@ -173,7 +173,7 @@ const char *acc_port_type_string(int pt) {
 }
 
 void acc_inductive_mode_string(int mode, char *pbuf) {
-	if (mode < 4) {
+	if (mode >= 0 && mode < 4) {
 		strcpy(pbuf,_C(acc_inductive_modes[mode]));
 		return;
 	}
@@ -440,7 +440,6 @@ accessory_info_t get_acc_info(io_connect_t connect) {
 
 accessory_powermode_t get_acc_powermode(io_connect_t connect) {
 	accessory_powermode_t mode;
-	CFArrayRef supported;
 
 	memset(&mode, 0, sizeof(mode));
 
@@ -448,49 +447,74 @@ accessory_powermode_t get_acc_powermode(io_connect_t connect) {
 		mode.mode = IOAccessoryManagerGetPowerMode(connect);
 		mode.active = IOAccessoryManagerGetActivePowerMode(connect);
 	} else {
-		CFNumberRef number;
-		number = (CFNumberRef)IORegistryEntryCreateCFProperty(connect, CFSTR("IOAccessoryPowerMode"), kCFAllocatorDefault, kNilOptions);
-		if (!number || !CFNumberGetValue(number, kCFNumberSInt32Type, &mode.mode)) {
+		CFTypeRef property = IORegistryEntryCreateCFProperty(connect, CFSTR("IOAccessoryPowerMode"), kCFAllocatorDefault, kNilOptions);
+		SInt32 powerMode;
+		if (!property || CFGetTypeID(property) != CFNumberGetTypeID() ||
+		    !CFNumberGetValue((CFNumberRef)property, kCFNumberSInt32Type, &powerMode)) {
 			mode.mode = 0;
+		} else {
+			mode.mode = powerMode;
 		}
-		number = (CFNumberRef)IORegistryEntryCreateCFProperty(connect, CFSTR("IOAccessoryActivePowerMode"), kCFAllocatorDefault, kNilOptions);
-		if (!number || !CFNumberGetValue(number, kCFNumberSInt32Type, &mode.active)) {
+		if (property) CFRelease(property);
+
+		property = IORegistryEntryCreateCFProperty(connect, CFSTR("IOAccessoryActivePowerMode"), kCFAllocatorDefault, kNilOptions);
+		if (!property || CFGetTypeID(property) != CFNumberGetTypeID() ||
+		    !CFNumberGetValue((CFNumberRef)property, kCFNumberSInt32Type, &powerMode)) {
 			mode.active = 0;
+		} else {
+			mode.active = powerMode;
 		}
-		if (number) CFRelease(number);
+		if (property) CFRelease(property);
 	}
 
-	supported = IORegistryEntryCreateCFProperty(connect, CFSTR("IOAccessorySupportedPowerModes"), kCFAllocatorDefault, kNilOptions);
-	if (supported) {
+	CFTypeRef supportedProperty = IORegistryEntryCreateCFProperty(connect, CFSTR("IOAccessorySupportedPowerModes"), kCFAllocatorDefault, kNilOptions);
+	if (supportedProperty && CFGetTypeID(supportedProperty) == CFArrayGetTypeID()) {
+		CFArrayRef supported = (CFArrayRef)supportedProperty;
 #if DEBUG
 		printf("Powermodes: ");
 		CFShow(supported);
 #endif
-		mode.supported_cnt = CFArrayGetCount(supported);
-		for (int i = 0; i < mode.supported_cnt; i++) {
-			CFNumberRef value = CFArrayGetValueAtIndex(supported, i);
-			if (CFNumberGetValue(value, kCFNumberSInt32Type, &mode.supported[i])) {
-				if (use_libioam)
-					mode.supported_lim[i] = IOAccessoryManagerPowerModeCurrentLimit(connect, mode.supported[i]);
-				else {
-					CFArrayRef array = IORegistryEntryCreateCFProperty(connect, CFSTR("IOAccessoryPowerCurrentLimits"), kCFAllocatorDefault, kNilOptions);
-					if (array) {
-						if (mode.supported[i]) {
-							CFIndex modeIndex = mode.supported[i] - 1;
-							if (CFArrayGetCount(array) > i) {
-								CFNumberRef number = CFArrayGetValueAtIndex(array, modeIndex);
-								if (number)
-									CFNumberGetValue(number, kCFNumberSInt32Type, &mode.supported_lim[i]);
-							}
+		CFTypeRef limitsProperty = NULL;
+		CFArrayRef limits = NULL;
+		if (!use_libioam) {
+			limitsProperty = IORegistryEntryCreateCFProperty(connect, CFSTR("IOAccessoryPowerCurrentLimits"), kCFAllocatorDefault, kNilOptions);
+			if (limitsProperty && CFGetTypeID(limitsProperty) == CFArrayGetTypeID()) {
+				limits = (CFArrayRef)limitsProperty;
+			}
+		}
+
+		const size_t supportedCapacity = sizeof(mode.supported) / sizeof(mode.supported[0]);
+		CFIndex reportedCount = CFArrayGetCount(supported);
+		for (CFIndex i = 0; i < reportedCount && mode.supported_cnt < supportedCapacity; i++) {
+			CFTypeRef value = CFArrayGetValueAtIndex(supported, i);
+			SInt32 powerMode;
+			if (!value || CFGetTypeID(value) != CFNumberGetTypeID() ||
+			    !CFNumberGetValue((CFNumberRef)value, kCFNumberSInt32Type, &powerMode)) {
+				continue;
+			}
+
+			size_t destinationIndex = mode.supported_cnt++;
+			mode.supported[destinationIndex] = powerMode;
+			if (powerMode >= kIOAMPowermodeOff && powerMode <= kIOAMPowermodeCount) {
+				if (use_libioam) {
+					mode.supported_lim[destinationIndex] = IOAccessoryManagerPowerModeCurrentLimit(connect, powerMode);
+				} else if (limits) {
+					CFIndex limitIndex = (CFIndex)powerMode - kIOAMPowermodeOff;
+					if (limitIndex < CFArrayGetCount(limits)) {
+						CFTypeRef limitValue = CFArrayGetValueAtIndex(limits, limitIndex);
+						SInt32 currentLimit;
+						if (limitValue && CFGetTypeID(limitValue) == CFNumberGetTypeID() &&
+						    CFNumberGetValue((CFNumberRef)limitValue, kCFNumberSInt32Type, &currentLimit) &&
+						    currentLimit >= 0) {
+							mode.supported_lim[destinationIndex] = currentLimit;
 						}
-						CFRelease(array);
 					}
 				}
 			}
-			if (value) CFRelease(value);
 		}
+		if (limitsProperty) CFRelease(limitsProperty);
 	}
-	if (supported) CFRelease(supported);
+	if (supportedProperty) CFRelease(supportedProperty);
 
 	return mode;
 }

--- a/Battman/battery_utils/accessory.c
+++ b/Battman/battery_utils/accessory.c
@@ -2,6 +2,7 @@
 #include "../common.h"
 //#include "intlextern.h"
 #include <mach/mach.h>
+#include <stdarg.h>
 
 io_iterator_t gAccessories;
 io_service_t gAccPrimary;
@@ -114,14 +115,37 @@ static const char *acc_inductive_modes[] = {
 extern const char *cond_localize_c(const char *);
 #define _C(x) cond_localize_c(x)
 
-void acc_powermode_string(AccessoryPowermode powermode, char **pbuf) {
-	// IOAM modes are starting form 1
-	if (powermode >= kIOAMPowermodeOff && powermode <= kIOAMPowermodeCount) {
-		*pbuf=stpcpy(*pbuf,_C(acc_powermodes[powermode - 1]));
+static void acc_append_string(char **pbuf, size_t *remaining,
+    const char *format, ...) {
+	if (!pbuf || !*pbuf || !remaining || *remaining == 0 || !format)
+		return;
+
+	va_list args;
+	va_start(args, format);
+	int written = vsnprintf(*pbuf, *remaining, format, args);
+	va_end(args);
+	if (written < 0) {
+		**pbuf = '\0';
 		return;
 	}
 
-	(*pbuf) +=sprintf(*pbuf, "<%d>", powermode);
+	size_t used = (size_t)written;
+	if (used >= *remaining)
+		used = *remaining - 1;
+	*pbuf += used;
+	*remaining -= used;
+}
+
+void acc_powermode_string(AccessoryPowermode powermode, char **pbuf,
+    size_t *remaining) {
+	// IOAM modes are starting form 1
+	if (powermode >= kIOAMPowermodeOff && powermode <= kIOAMPowermodeCount) {
+		acc_append_string(pbuf, remaining, "%s",
+		    _C(acc_powermodes[powermode - 1]));
+		return;
+	}
+
+	acc_append_string(pbuf, remaining, "<%d>", powermode);
 }
 const char *acc_usb_connstat_string(int usb_connstat) {
 	if (usb_connstat > 5) return _C("Unknown");
@@ -129,18 +153,41 @@ const char *acc_usb_connstat_string(int usb_connstat) {
 	return _C(acc_usb_connstats[usb_connstat]);
 }
 
-void acc_powermode_string_supported(accessory_powermode_t mode, char **pbuf) {
-	if (mode.supported_cnt == 0) {
-		**pbuf=0;
+void acc_powermode_string_supported(accessory_powermode_t mode, char **pbuf,
+    size_t *remaining) {
+	size_t supportedCount = mode.supported_cnt;
+	size_t supportedCapacity = sizeof(mode.supported) / sizeof(mode.supported[0]);
+	if (supportedCount > supportedCapacity)
+		supportedCount = supportedCapacity;
+	if (supportedCount == 0) {
+		if (pbuf && *pbuf && remaining && *remaining)
+			**pbuf = '\0';
 		return;
 	}
 
-	(*pbuf)+=sprintf(*pbuf, "%s: ", _C("Supported List"));
-	for (size_t i = 0; i < mode.supported_cnt; i++) {
-		(*pbuf)+=sprintf(*pbuf, "%s", (i == 0) ? "" : "\n");
-		acc_powermode_string(mode.supported[i],pbuf);
-		(*pbuf)+=sprintf(*pbuf, "<%lu %s>", mode.supported_lim[i], L_MA);
+	acc_append_string(pbuf, remaining, "%s: ", _C("Supported List"));
+	for (size_t i = 0; i < supportedCount; i++) {
+		acc_append_string(pbuf, remaining, "%s", (i == 0) ? "" : "\n");
+		acc_powermode_string(mode.supported[i], pbuf, remaining);
+		acc_append_string(pbuf, remaining, "<%lu %s>",
+		    mode.supported_lim[i], L_MA);
 	}
+}
+
+void acc_powermode_details_string(accessory_powermode_t mode, char *pbuf,
+    size_t capacity) {
+	if (!pbuf || capacity == 0)
+		return;
+
+	char *cursor = pbuf;
+	size_t remaining = capacity;
+	*pbuf = '\0';
+	acc_append_string(&cursor, &remaining, "%s: ", _C("Configured Mode"));
+	acc_powermode_string(mode.mode, &cursor, &remaining);
+	acc_append_string(&cursor, &remaining, "\n%s: ", _C("Active Mode"));
+	acc_powermode_string(mode.active, &cursor, &remaining);
+	acc_append_string(&cursor, &remaining, "\n");
+	acc_powermode_string_supported(mode, &cursor, &remaining);
 }
 
 void acc_usb_ilim_string_multiline(accessory_usb_ilim_t ilim, char *pbuf) {

--- a/Battman/battery_utils/accessory.h
+++ b/Battman/battery_utils/accessory.h
@@ -57,8 +57,12 @@ const char *acc_id_string(int accid);
 const char *acc_port_type_string(int pt);
 const char *manf_id_string(int manf);
 const char *apple_prod_id_string(int prod);
-void acc_powermode_string(AccessoryPowermode powermode,char**);
-void acc_powermode_string_supported(accessory_powermode_t mode,char**);
+void acc_powermode_string(AccessoryPowermode powermode, char **pbuf,
+    size_t *remaining);
+void acc_powermode_string_supported(accessory_powermode_t mode, char **pbuf,
+    size_t *remaining);
+void acc_powermode_details_string(accessory_powermode_t mode, char *pbuf,
+    size_t capacity);
 void acc_usb_ilim_string_multiline(accessory_usb_ilim_t ilim,char*);
 const char *acc_usb_connstat_string(int usb_connstat);
 void acc_inductive_mode_string(int mode,char*);

--- a/Battman/battery_utils/battery_info.c
+++ b/Battman/battery_utils/battery_info.c
@@ -888,7 +888,6 @@ void accessory_info_update(struct battery_info_section *section) {
 	
 	// This is temporary, subcells will be implemented to replace this terrible impl.
 	char str_buf[512];
-	char *bufptr=str_buf;
 
 	/* IOAM Part */
 	const char *idstr = acc_id_string(acc_id);
@@ -905,13 +904,7 @@ void accessory_info_update(struct battery_info_section *section) {
 	BI_FORMAT_ITEM_IF(*accinfo.hwVer, _C("Hardware Version"), "%s", accinfo.hwVer);
 	BI_FORMAT_ITEM(_C("Battery Pack"), "%s", get_acc_battery_pack_mode(connect) ? L_TRUE : L_FALSE);
 	
-	bufptr+=sprintf(bufptr,"%s: ",cond_localize_c("Configured Mode"));
-	acc_powermode_string(mode.mode,&bufptr);
-	*(bufptr++)='\n';
-	bufptr+=sprintf(bufptr,"%s: ",cond_localize_c("Active Mode"));
-	acc_powermode_string(mode.active,&bufptr);
-	*(bufptr++)='\n';
-	acc_powermode_string_supported(mode,&bufptr);
+	acc_powermode_details_string(mode, str_buf, sizeof(str_buf));
 	BI_FORMAT_ITEM(_C("Power Mode"), "%s", str_buf);
 	if (sleep.supported) {
 		BI_FORMAT_ITEM(_C("Sleep Power"), "%s\n%s: %d", sleep.enabled ? cond_localize_c("Enabled") : cond_localize_c("Disabled"), cond_localize_c("Limit"), sleep.limit);

--- a/Battman/battery_utils/battery_info.c
+++ b/Battman/battery_utils/battery_info.c
@@ -4,8 +4,10 @@
 #include "accessory.h"
 #include "libsmc.h"
 #include <assert.h>
+#include <stdarg.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <pthread.h>
@@ -347,21 +349,25 @@ void bi_node_set_hidden(struct battery_info_node *node, int identifier,
 
 #include <mach/mach.h>
 
+enum { BI_NODE_STRING_CAPACITY = 256 };
+
 char *bi_node_ensure_string(struct battery_info_node *node, int identifier,
     uint64_t length) {
 	node += identifier;
 	assert(!(node->content & BIN_IS_SPECIAL));
+	if (length > BI_NODE_STRING_CAPACITY)
+		return NULL;
 
 	if (!node->content) {
 		void *allocen = (void *)0x10000000;
 		// ^ Preferred addr
 		// Use vm_allocate to prevent possible unexpected heap allocation (it
 		// crashes in current data structure)
-		// TODO: get rid of hardcoded length
-		int   result  = vm_allocate(mach_task_self(), (vm_address_t *)&allocen, 256, VM_FLAGS_ANYWHERE);
+		int   result  = vm_allocate(mach_task_self(), (vm_address_t *)&allocen,
+		    BI_NODE_STRING_CAPACITY, VM_FLAGS_ANYWHERE);
 		if (result != KERN_SUCCESS) {
 			// Fallback to malloc
-			// allocen = malloc(length);
+			// allocen = malloc(BI_NODE_STRING_CAPACITY);
 			allocen = nil;
 		}
 		node->content = (uint32_t)(((uint64_t)allocen) >> 3);
@@ -377,7 +383,8 @@ void bi_node_free_string(struct battery_info_node *node) {
 	uint32_t old = __atomic_exchange_n(&node->content, 0, __ATOMIC_ACQ_REL);
 	if (!old)
 		return;
-	vm_deallocate(mach_task_self(), (vm_address_t)(((uint64_t)old)<<3), 256);
+	vm_deallocate(mach_task_self(), (vm_address_t)(((uint64_t)old)<<3),
+	    BI_NODE_STRING_CAPACITY);
 }
 
 static int _impl_set_item_find_item(struct battery_info_node **head, const char *desc) {
@@ -411,7 +418,7 @@ static char *_impl_set_item(struct battery_info_node **head, const char *desc,
 			}
 			return NULL;
 		}
-		return bi_node_ensure_string(i, 0, 256);
+		return bi_node_ensure_string(i, 0, BI_NODE_STRING_CAPACITY);
 	} else if (options == 1) {
 		bi_node_set_hidden(i, 0, (bool)value);
 	} else if ((i->content & BIN_IS_FLOAT) == BIN_IS_FLOAT) {
@@ -423,13 +430,28 @@ static char *_impl_set_item(struct battery_info_node **head, const char *desc,
 	return NULL;
 }
 
+static void _impl_format_item(struct battery_info_node **head, const char *desc,
+    const char *format, ...) __attribute__((format(printf, 3, 4)));
+
+static void _impl_format_item(struct battery_info_node **head, const char *desc,
+    const char *format, ...) {
+	char *buffer = _impl_set_item(head, desc, 0, 0, 2);
+	if (!buffer || !format)
+		return;
+
+	va_list args;
+	va_start(args, format);
+	(void)vsnprintf(buffer, BI_NODE_STRING_CAPACITY, format, args);
+	va_end(args);
+}
+
 #define BI_SET_ITEM(name, value) \
 	_impl_set_item(head_arr, name, (uint64_t)(value), (float)(value), 0)
 
 #define BI_ENSURE_STR(name) _impl_set_item(head_arr, name, 0, 0, 2)
 
 #define BI_FORMAT_ITEM(name, ...) \
-	sprintf(_impl_set_item(head_arr, name, 0, 0, 2), __VA_ARGS__)
+	_impl_format_item(head_arr, name, __VA_ARGS__)
 
 #define BI_SET_ITEM_IF(cond, name, value)        \
 	if (cond) {                                  \
@@ -846,7 +868,10 @@ void accessory_info_update(struct battery_info_section *section) {
 	accessory_info_t accinfo              = get_acc_info(connect);
 	accessory_powermode_t mode            = get_acc_powermode(connect);
 	accessory_sleeppower_t sleep          = get_acc_sleeppower(connect);
-	iktara_accessory_array_t array;
+	iktara_accessory_array_t array            = {
+		.charging = -1,
+		.capacity = -1,
+	};
 	accessory_usb_connstat_t connstat;
 	accessory_usb_ilim_t ilim;
 	int inductive_fw_mode                 = get_acc_inductive_fw_mode(connect);
@@ -991,8 +1016,9 @@ void accessory_info_update(struct battery_info_section *section) {
 	} else if (context->primary_port == 257) {
 		/* TODO: Scorpius */
 	}
-	acc_inductive_mode_string(inductive_fw_mode,str_buf);
-	BI_FORMAT_ITEM_IF(inductive_fw_mode != -1, _C("Inductive FW Mode"), "%s", str_buf);
+	if (inductive_fw_mode >= 0)
+		acc_inductive_mode_string(inductive_fw_mode, str_buf);
+	BI_FORMAT_ITEM_IF(inductive_fw_mode >= 0, _C("Inductive FW Mode"), "%s", str_buf);
 	BI_FORMAT_ITEM_IF(inductive_region != -1, _C("Inductive Region Code"), "0x%04x (%c%c)", (uint16_t)inductive_region, (inductive_region & 0xFF00) >> 8, inductive_region & 0xFF);
 	BI_SET_ITEM_IF(inductive_timeout, _C("Inductive Auth Timeout"), inductive_timeout);
 	/* MagSafe Charger: kHIDPage_AppleVendor:17 */
@@ -1005,28 +1031,11 @@ void accessory_info_update(struct battery_info_section *section) {
 	// check UPSMonitor.m
 	// FIXME: kIOAccessoryPortIDSerial added as a workaround of cell init, try fix bi_make_section
 	if (smc_vendor || hid_vendor || context->primary_port == kIOAccessoryPortIDSerial) {
-		UPSDataRef device = UPSDeviceMatchingVendorProduct(vid, pid);
-		ups_batt_t info = {0};
-
-		int cell_count = 0;
-		if (device != NULL) {
-			info = ups_battery_info(device);
-
-			CFIndex caps_count = CFSetGetCount(device->upsCapabilities);
-			for (CFIndex i = 0; i < caps_count; i++) {
-				CFStringRef val = CFStringCreateWithFormat(kCFAllocatorDefault, NULL, CFSTR("Cell %ld Voltage"), i);
-				if (val && CFSetContainsValue(device->upsCapabilities, val)) {
-					cell_count++;
-					CFRelease(val);
-					continue;
-				} else {
-					if (val) CFRelease(val);
-					break;
-				}
-			}
-		}
+		UPSBatterySnapshot snapshot = {0};
+		UPSCopyBatterySnapshot(vid, pid, &snapshot);
+		ups_batt_t info = snapshot.battery;
 		/* We are not ready to display Cell specs for any batteries (But defined in headers) */
-		BI_SET_ITEM_IF(cell_count != 0, ("Cell Count"), cell_count);
+		BI_SET_ITEM_IF(snapshot.cell_count != 0, ("Cell Count"), snapshot.cell_count);
 		/* Sadly, UPS does not got reports on Designed Capacity */
 		BI_SET_ITEM_IF(info.current_capacity != 0, _C("Current Capacity"), info.current_capacity);
 		BI_SET_ITEM_IF(info.max_capacity != 0, _C("Max Capacity"), info.max_capacity);


### PR DESCRIPTION
## Root cause

UPS monitoring mixed CoreFoundation ownership rules with a `UPSDataRef` allocated by `calloc`. Teardown attempted to `CFRetain()` that C allocation, while vendor/product lookup returned a borrowed pointer after releasing the device-set lock. A detach notification could therefore free the record while the details updater was still reading it.

Accessory parsing also trusted power-mode values and property sizes supplied by IOKit. Missing mode properties produced zero and then indexed element `-1`; oversized supported-mode arrays wrote beyond fixed stack arrays; and borrowed `CFArrayGetValueAtIndex()` elements were released as though they were owned. Battery detail strings were formatted with unbounded `sprintf()` into a fixed 256-byte allocation, and serial/non-SMC fallback data could be read before initialization.

## User impact

Unplugging a UPS or HID battery during a details refresh, stopping monitoring, opening details for a non-inductive accessory, or reading incomplete power-mode properties could crash Battman. Malformed or newer accessory properties and long names or identifiers could also corrupt heap, stack, or CoreFoundation state instead of failing safely.

## Changes made

- Give `UPSDataRef` explicit atomic retain/release ownership rather than treating it as a CoreFoundation object.
- Replace the borrowed vendor/product lookup with `UPSCopyBatterySnapshot()`, which copies battery and cell data while the global device set is locked.
- Make device-set add, remove, snapshot, reconciliation, and shutdown ownership transitions atomic under one mutex.
- Detach notification objects, plug-in interfaces, event sources, and timers exactly once; invalidate and release them without blocks capturing an unretained C struct.
- Keep the watcher joinable and serialize start, stop, cleanup, background, and foreground transitions. Startup now waits for complete notification setup, and failed workers are joined and reaped.
- Reconcile the cached UPS set against registry IDs after foregrounding so devices disconnected while notifications were paused do not remain stale.
- Validate CoreFoundation property types and power-mode lower and upper bounds, cap supported modes to the fixed destination arrays, preserve borrowed array ownership, and bounds-check current-limit lookup by the reported mode.
- Reject negative inductive modes before formatting and initialize Iktara fallback fields to unavailable sentinels.
- Route battery detail formatting through `vsnprintf()` with the shared 256-byte node capacity.

## Before and after

For an accessory missing `IOAccessoryPowerMode`:

- Before: the fallback value was zero, `powermode - 1` became `-1`, and Battman indexed before `acc_powermodes`.
- After: zero is rejected before indexing and is rendered through the existing unknown-mode fallback.

For a UPS disconnected during battery-info refresh:

- Before: the lookup returned a pointer after unlocking, so the detach callback could free it before `ups_battery_info()` used it.
- After: the details updater receives a value snapshot created while the device record is protected.

For a formatted value longer than the node allocation:

- Before: `sprintf()` could write beyond 256 bytes.
- After: output is limited to 255 bytes plus the terminating NUL.

## Test and build results

- Accessory ASan/UBSan harness passed missing mode values, lower and upper mode boundaries, malformed properties, borrowed array elements, sparse current limits, and more reported modes than the fixed destination capacity.
- Battery-format ASan/UBSan harness passed a 599-byte input and verified truncation to 255 bytes plus NUL.
- UPS ASan/UBSan harness passed 2,000 add/remove cycles with three concurrent snapshot readers, retained copies surviving set removal, notification-owner teardown, 20 immediate start/stop cycles, background/foreground transitions, and missing-device reconciliation.
- The same UPS harness passed 10 rounds of 12 simultaneous `startWatchingUPS` callers while verifying that exactly one worker was created per round.
- The expanded UPS harness passed under ThreadSanitizer with no races or lock-order reports.
- `git diff --check` and focused scans for the invalid retain, raw pointer lookup, borrowed-value release, unbounded formatter, and uncapped supported-mode count passed.
- Debug simulator builds passed for `Battman`, `Battman (rel-nonfree)`, `Battman-havoc`, and `Battman-havoc-tipa` using `~/Downloads/Xcode.app`.

## Intentionally unchanged

- Battery capacity, charging, temperature, and time-estimate display semantics are unchanged.
- No new accessory power modes or current-limit values are inferred; unsupported or malformed values fail safely.
- Existing localization and battery-diagnostic wording are unchanged.
- The legacy UPS implementation remains disabled by the existing `USE_NEW_UPSMONITOR` default.

## Compatibility with #46

This branch is based directly on `master` and does not depend on #46. A temporary-index apply check against `fix/battery-diagnostic-units` passed. The only shared file is `battery_info.c`, and the two changes touch disjoint hunks, so either PR can land first.

## References

- #46


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved UPS monitoring reliability across device disconnect/reconnect and background/foreground transitions.
  - Prevented partial/invalid runtime state from affecting displayed UPS and accessory battery details.
  - Enhanced UPS battery cell-count detection for more accurate reporting.
  - Hardened accessory power-mode and current-limit parsing, ensuring unsupported or malformed data is handled safely.
  - Improved shutdown and teardown behavior to reduce stale monitoring state and related resource issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->